### PR TITLE
fix: CI cache + scrub EU MoD / NATO from README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,10 @@ jobs:
       - uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ matrix.python }}
-          cache: pip
+          # No cache: actions/setup-python's pip-cache key requires a
+          # requirements.txt or pyproject.toml; we ship neither today
+          # because the runtime has no deps beyond stdlib + optional
+          # numpy.  Re-enable when we add packaging metadata.
 
       - name: Install dev dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ stable JSON schema designed for fleet inventory aggregation.
 ## Audience
 
 Field architects and customer infrastructure teams. The tool is intended
-for use during EU MoD / NATO and other regulated-environment PQC
-migration engagements. It runs on bare metal RHEL 8/9/10, in containers
-(podman/quadlet), and as a privileged DaemonSet on OpenShift.
+for use during regulated-environment PQC migration engagements. It runs
+on bare metal RHEL 8/9/10, in containers (podman/quadlet), and as a
+privileged DaemonSet on OpenShift.
 
 ## What it detects
 


### PR DESCRIPTION
Two fixes that should have ridden in PR #2:

1. **CI failure on every Python version.** `actions/setup-python@v6.2.0` with `cache: pip` requires a `requirements.txt` or `pyproject.toml` to compute a cache key; we ship neither (the runtime has no deps beyond stdlib + optional numpy).  Drop the `cache: pip` line.  Inline comment documents the re-enable path once we add packaging metadata.

2. **README EU MoD / NATO scrub.** Commit `a0d1079` on the previous feature branch did not make it into the PR #2 merge — main still carries the customer-specific phrasing in the audience section.  Reapplying the scrub.

## Test plan
- [x] Local: `ruff check`, `mypy --strict pqc_readiness.py`, `pytest -q` all clean (49 tests)
- [x] grep for `EU MoD|NATO` in repo: clean
- [ ] CI workflow on this PR: lint + tests across Python 3.11 / 3.12 / 3.13 (will trigger on push)
