### PR TITLE
cleanup: remove third-party product references from issues, PRs, and code

### DIFF
--- a/.github/workflows/no-third-party-refs.yml
+++ b/.github/workflows/no-third-party-refs.yml
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+# Reject third-party product references on PRs.  See CONTRIBUTING.md
+# "Third-party product references" for the underlying policy.
+
+name: no-third-party-refs
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: scan working tree for third-party product references
+        run: bash scripts/check-no-third-party-refs.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing to pqc-readiness
+
+## Third-party product references
+
+This project does not name specific competing products in issues, pull
+request descriptions, documentation, or code. Justifications anchor on
+the underlying standards (NIST, IETF, OASIS, CycloneDX, SPDX, IANA), not
+on what other tools do.
+
+The reason is concrete: naming products creates trademark exposure,
+invites disparagement disputes, and signals a competitive stance the
+project has not taken. Standards bodies and their publications are
+neutral; product names are not.
+
+### Examples
+
+Unacceptable:
+
+> We should emit SARIF because Tool-X emits SARIF.
+
+> Align field names with Tool-Y's schema where there is overlap.
+
+> Borrow the methodology from Tool-Z.
+
+Acceptable:
+
+> SARIF (OASIS standard) is the standard exchange format for
+> code-scanning and security findings. Most security tooling consumes
+> it.
+
+> Align field names with the established cryptographic inventory schemas
+> (CycloneDX 1.6 cryptographic-assets, NIST IR 8547) where conventions
+> exist.
+
+> Use TLS handshake-level measurement as specified in RFC 8446.
+
+### What this rule does *not* forbid
+
+Standards-body publications and registries are fair game and should be
+cited explicitly:
+
+- NIST FIPS 203 / 204 / 205, NIST IR 8547, CNSA 2.0
+- IETF drafts and RFCs (TLS hybrid design, composite signatures, etc.)
+- OASIS SARIF
+- CycloneDX, SPDX
+- IANA registries
+
+### Lint
+
+The rule is enforced by `scripts/check-no-third-party-refs.sh` and the
+`no-third-party-refs` GitHub Actions workflow. The forbidden-pattern
+list is the single source of truth at `scripts/forbidden-refs.txt`; if a
+new product name needs to be reserved, extend that file in a PR.
+
+Run locally before committing:
+
+    bash scripts/check-no-third-party-refs.sh
+
+Exit codes: 0 clean, 1 forbidden references found, 2 configuration
+error.

--- a/scripts/check-no-third-party-refs.sh
+++ b/scripts/check-no-third-party-refs.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Reject third-party product references in the working tree.
+# See CONTRIBUTING.md "Third-party product references" for policy.
+#
+# Usage: scripts/check-no-third-party-refs.sh
+# Exit:  0 if clean, 1 if forbidden refs found, 2 on configuration error
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+PATTERN_FILE="$REPO_ROOT/scripts/forbidden-refs.txt"
+
+if [[ ! -f "$PATTERN_FILE" ]]; then
+  echo "error: $PATTERN_FILE not found" >&2
+  exit 2
+fi
+
+cd "$REPO_ROOT"
+
+EXCLUDE=(
+  ':!scripts/forbidden-refs.txt'
+  ':!scripts/check-no-third-party-refs.sh'
+  ':!.github/workflows/no-third-party-refs.yml'
+  ':!CONTRIBUTING.md'
+)
+
+if git grep -nIE -f "$PATTERN_FILE" -- "${EXCLUDE[@]}"; then
+  echo
+  echo "Found forbidden third-party product references." >&2
+  echo "See CONTRIBUTING.md 'Third-party product references' for policy." >&2
+  exit 1
+fi
+
+echo "OK: no third-party product references found."

--- a/scripts/forbidden-refs.txt
+++ b/scripts/forbidden-refs.txt
@@ -1,0 +1,25 @@
+QRAMM
+CryptoScan
+CryptoDeps
+TLS Analyzer
+PQC-Bench
+pqcscan
+PQC-Scanner
+PQC-LEO
+Crypto-Scanner
+Quantum-Safe Code Auditor
+\bKeyfactor\b
+\bCryptoServe\b
+QBOM
+qramm\.org
+csnp\.org
+github\.com/csnp
+github\.com/cyberjez
+github\.com/crt26
+github\.com/mbennett-labs
+keyfactor\.com
+Quantum Shield Labs
+mbennett-labs
+cyberjez
+crt26
+\bcsnp\b


### PR DESCRIPTION
## Summary

Removes third-party product references from the pqc-readiness issue queue and adds a lint guardrail to prevent recurrence. Anchors justifications on underlying standards (NIST, IETF, OASIS, CycloneDX, SPDX) rather than naming specific competing products. Trademark exposure, disparagement disputes, and an unintentional competitive stance are the concrete reasons.

The cleanup is tracked here in lieu of a GitHub issue, per the task spec's "Don't add new issues as part of this cleanup" directive.

## Discovery summary (phase 1)

| Surface | Affected |
|---|---|
| Issues — open | 7 (#5, #7, #8, #9, #12, #13, #14) |
| Issues — closed | 1 (#11) |
| Issue titles needing rewrite | 4 (#8, #12, #13, #14) |
| PRs — open / merged / closed | 0 / 0 / 0 |
| Branches with forbidden names | 0 |
| Code/doc files with hits | 0 |
| Commits with forbidden refs | 0 across all branches |

A working-tree match in `pqc_readiness.py:815` (a legitimate HSM detection target — a vendor's client path) was caused by an over-broad token in the pattern matching as a substring. The pattern was tightened with `\b` word boundaries on three short or substring-prone tokens so legitimate HSM vendor names are not affected.

## Phase 2 — issue body rewrites (already applied)

Eight issue bodies were rewritten via `gh issue edit --body-file` and a cleanup comment posted on each. Titles were also rewritten where the title itself contained a forbidden reference:

- #5 — body rewrite
- #7 — body rewrite
- #8 — title + body rewrite
- #9 — body rewrite
- #11 — body rewrite (closed; merged via PR #15)
- #12 — title + body rewrite
- #13 — title + body rewrite
- #14 — title + body rewrite

Acceptance criteria preserved in substance. Two deliverable filenames adjusted (#8 and #14) so the docs they produce are anchored on the underlying standards rather than on a tool-by-tool mapping, per the task-spec hint to "describe categories of tools, not name them."

## Phase 3 — PR description rewrites

No-op: zero open/closed/merged PR bodies contained forbidden references.

## Phase 4 — code/doc rewrites

No-op for existing content: the working tree on `main` and on every remote branch is already clean. This PR's diff is solely the phase 6 lint guardrails.

## Phase 5 — commit-message rewrites (deferred artefacts)

- `/tmp/commits-to-rewrite.txt` — empty
- `/tmp/rewrite-plan.md` — records "no work required"
- `/tmp/merged-prs-with-references.txt` — empty
- `/tmp/branches-to-rename-later.txt` — empty

Across all branches, both subject-line and full-body grep returned zero hits. No commit-message rewrites are required.

## Phase 6 — guardrails (this PR's diff)

| File | Purpose |
|---|---|
| `scripts/forbidden-refs.txt` | Single source of truth for the pattern list |
| `scripts/check-no-third-party-refs.sh` | Local lint and CI runner |
| `.github/workflows/no-third-party-refs.yml` | CI enforcement on PR + main push |
| `CONTRIBUTING.md` | Policy explanation with placeholder examples |

The script excludes the pattern file, the script itself, the workflow, and `CONTRIBUTING.md` (which discusses the policy with placeholder examples — verified clean against the lint).

Smoke-tested locally: the script exits 0 on the cleanup branch's working tree and exits 1 (with the offending line printed) when a forbidden reference is planted in a tracked file.

## Phase 7 — verification

- Working tree on cleanup branch: 0 hits outside the allow-list
- All open issue bodies: 0 hits after edits
- Closed issue #11 body: 0 hits after edit
- Test suite: 57/57 passing (`pytest tests/ -q`)
- CodeRabbit: no findings (`cr --plain --type uncommitted`)
- CI on this PR: all 4 checks green (lint, lint+tests on 3.11 / 3.12 / 3.13)

## Test plan

- [x] `bash scripts/check-no-third-party-refs.sh` returns 0 on clean working tree
- [x] `bash scripts/check-no-third-party-refs.sh` returns 1 on planted forbidden reference
- [x] `pytest tests/ -q` passes (57/57)
- [x] `cr --plain --type uncommitted` returns no findings
- [x] `no-third-party-refs` CI workflow runs green on this PR
- [x] `ci` workflow (existing) runs green on this PR
