### PR TITLE
feat: add policy-aware PQC algorithm recommendation engine

### DIFF
--- a/docs/recommendation-policies.md
+++ b/docs/recommendation-policies.md
@@ -1,0 +1,126 @@
+# Recommendation policies
+
+`pqc-readiness --recommend --policy <name>` produces a host-specific
+algorithm recommendation that is only meaningful relative to a
+compliance regime. Different cryptographic authorities hold materially
+different positions on hybrid vs. pure-PQC preference, so a single
+hardcoded recommendation is wrong for the majority of users regardless
+of what it says.
+
+This document is the audit trail for the recommendation engine: every
+policy enumerated below names the issuing authority, links to the
+authoritative document, and states the position the engine encodes.
+
+The policy-to-preference mapping itself lives as a single declarative
+dictionary (`POLICY_PREFERENCES`) in `pqc_readiness.py`. Updating a
+policy when an authority revises guidance is a one-place edit; it must
+not require touching the engine.
+
+## `cnsa-2.0` — US National Security Systems
+
+- **Authority:** NSA, Commercial National Security Algorithm Suite 2.0
+- **Source:**
+  - CNSA 2.0 advisory:
+    https://media.defense.gov/2022/Sep/07/2003071834/-1/-1/0/CSA_CNSA_2.0_ALGORITHMS_.PDF
+  - CNSA 2.0 FAQ:
+    https://media.defense.gov/2022/Sep/07/2003071836/-1/-1/0/CSI_CNSA_2.0_FAQ_.PDF
+- **Position:** ML-KEM-1024 and ML-DSA-87 for National Security
+  Systems. Pure PQC is preferred. Hybrid is permitted only where a
+  protocol mandates it (e.g., IKEv2 per RFC 9370).
+- **Hash:** SHA-384.
+- **Engine output:**
+  - KEM: `ML-KEM-1024` (pure)
+  - Signature: `ML-DSA-87`
+  - Hash: `SHA-384`
+  - FIPS-validated cryptographic modules required.
+
+## `nist-civilian` — US federal civilian / FCEB
+
+- **Authority:** NIST
+- **Source:**
+  - FIPS 203 (ML-KEM): https://csrc.nist.gov/pubs/fips/203/final
+  - FIPS 204 (ML-DSA): https://csrc.nist.gov/pubs/fips/204/final
+  - FIPS 205 (SLH-DSA): https://csrc.nist.gov/pubs/fips/205/final
+  - NIST IR 8547: https://csrc.nist.gov/pubs/ir/8547/final
+  - NIST SP 800-56C Rev. 2:
+    https://csrc.nist.gov/pubs/sp/800/56/c/r2/final
+  - NIST SP 800-227: https://csrc.nist.gov/pubs/sp/800/227/final
+- **Position:** ML-KEM, ML-DSA, and SLH-DSA per FIPS 203/204/205 are
+  the standardized civilian suite. Hybrid key establishment is
+  permitted under SP 800-56C Rev. 2; it is not required.
+- **Hash:** SHA-256 or SHA-384 per FIPS 180-4 family.
+- **Engine output:**
+  - KEM: `ML-KEM-768` (pure; hybrid permitted)
+  - Signature: `ML-DSA-65`
+  - Hash: `SHA-256`
+  - FIPS-validated cryptographic modules required.
+
+## `eu-anssi-bsi` — ANSSI / BSI hybrid
+
+- **Authority:** ANSSI (France) and BSI (Germany)
+- **Source:**
+  - ANSSI position on PQC migration:
+    https://cyber.gouv.fr/publications/should-quantum-key-distribution-be-used-secure-communications
+  - BSI guidance on PQC:
+    https://www.bsi.bund.de/EN/Themen/Unternehmen-und-Organisationen/Informationen-und-Empfehlungen/Quantentechnologien-und-Post-Quanten-Kryptografie/quantentechnologien-und-post-quanten-kryptografie_node.html
+- **Position:** Both authorities recommend hybrid deployment of PQC
+  alongside a classical primitive throughout the migration period.
+  Pure-PQC deployments are discouraged until confidence in the new
+  primitives matures.
+- **Hash:** SHA-256 or SHA-384.
+- **Engine output:**
+  - KEM: `ML-KEM-768` (hybrid)
+  - Signature: `ML-DSA-65`
+  - Hash: `SHA-256`
+  - FIPS validation is not a precondition under EU guidance.
+
+## `commercial` — no specific compliance regime
+
+- **Authority:** none. This policy applies when no specific compliance
+  regime governs the deployment (general-purpose enterprise or
+  consumer software).
+- **Position:** Both pure-PQC and hybrid deployments are acceptable.
+  Hybrid is suggested for data with long-confidentiality requirements
+  on harvest-now-decrypt-later (HNDL) grounds.
+- **Hash:** SHA-256.
+- **Engine output:**
+  - KEM: `ML-KEM-768` (pure; hybrid suggested for HNDL data)
+  - Signature: `ML-DSA-65`
+  - Hash: `SHA-256`
+
+## `auto` — composite
+
+`--policy auto` (the default) emits one recommendation per real policy
+above, side by side, with no single "preferred" answer. Operators in
+unclear or multi-jurisdiction contexts should consult the side-by-side
+output and select the policy that matches their compliance scope.
+
+## How a policy update should be made
+
+1. Edit `POLICY_PREFERENCES` in `pqc_readiness.py`. This is the only
+   place the engine reads policy preferences from.
+2. Update the corresponding section in this document with the new
+   authority position and a citation to the publication that motivated
+   the change.
+3. Update the policy tests in `tests/test_recommendation.py` so the
+   expected algorithm names track the new policy.
+4. The engine itself (`recommend`, `_recommend_tls_server`,
+   `_recommend_one`) should not need changes for a routine policy
+   update — if it does, that is a sign the policy table needs another
+   field, not that the engine should special-case the new policy.
+
+The policy table is a snapshot in time. Tracking authority position
+changes is a maintenance task, not an automation goal.
+
+## Out of scope
+
+- Sector-specific guidance (financial, healthcare, telecom). Sectors
+  vary too widely; the four policies above cover the relevant
+  authorities they refer back to.
+- Country-specific policies beyond ANSSI / BSI / NSA / NIST. Add via
+  follow-up issues when a customer asks; do not pre-implement.
+- Long-term migration roadmap beyond the recommendation itself.
+- Auto-applying configuration to the host. The recommendation is
+  advisory; the operator applies it.
+- Recommendations for cryptographic primitives outside NIST FIPS
+  203/204/205.

--- a/pqc_readiness.py
+++ b/pqc_readiness.py
@@ -2853,6 +2853,465 @@ def overall_verdict(
 
 
 # ---------------------------------------------------------------------------
+# Algorithm recommendation engine
+# ---------------------------------------------------------------------------
+#
+# `recommend()` is a pure function over (Report, policy, role).  It does
+# NOT consult network or disk; everything it needs is already on the
+# Report.  The policy-to-preference mapping is a single declarative dict
+# (POLICY_PREFERENCES) so that authority position changes can be made
+# without touching the engine.  The authoritative document for each
+# policy is cited in `docs/recommendation-policies.md`.
+#
+# Five policy modes, four full and one composite:
+#   cnsa-2.0      US National Security Systems / NSA-aligned.  Pure PQC
+#                 preferred; hybrid permitted only where a protocol
+#                 mandates it (IKEv2).
+#   nist-civilian US federal civilian / FCEB.  ML-KEM, ML-DSA, SLH-DSA
+#                 per FIPS 203/204/205.  Hybrid permitted, not required.
+#   eu-anssi-bsi  EU public sector under ANSSI / BSI.  Hybrid actively
+#                 recommended throughout the migration period.
+#   commercial    No specific compliance regime.  Both pure and hybrid
+#                 acceptable; hybrid suggested for long-confidentiality
+#                 (HNDL-relevant) data.
+#   auto          Side-by-side recommendation under all four real
+#                 policies, with no single "preferred" answer.
+#
+# Roles:
+#   tls-server        fully implemented
+#   tls-client        stub: returns {"implemented": False, ...}
+#   signing-service   stub: returns {"implemented": False, ...}
+#   firmware-signing  stub: returns {"implemented": False, ...}
+#
+# The non-tls-server roles are intentionally stubs — see issue #13
+# acceptance criteria, which scope the first cut to tls-server.
+
+POLICY_PREFERENCES: dict[str, dict[str, Any]] = {
+    "cnsa-2.0": {
+        "name": "CNSA 2.0",
+        "authority": "NSA / CNSA 2.0 (US National Security Systems)",
+        "hybrid_policy": "discouraged",
+        "hybrid_allowed_for": ["ikev2"],
+        "kem_primary": "ML-KEM-1024",
+        "sig_primary": "ML-DSA-87",
+        "hash_primary": "SHA-384",
+        "requires_fips": True,
+        "citation": (
+            "CNSA 2.0 specifies ML-KEM-1024 and ML-DSA-87 for National "
+            "Security Systems.  Pure PQC is preferred; hybrid is "
+            "permitted only where a protocol mandates it (e.g., IKEv2)."
+        ),
+        "source": (
+            "NSA CSA / CSI on Commercial National Security Algorithm "
+            "Suite 2.0 (CNSA 2.0 advisory and FAQ)"
+        ),
+    },
+    "nist-civilian": {
+        "name": "NIST civilian / FCEB",
+        "authority": "NIST FIPS 203 / 204 / 205 (US federal civilian)",
+        "hybrid_policy": "permitted",
+        "hybrid_allowed_for": ["tls-server", "tls-client", "ikev2"],
+        "kem_primary": "ML-KEM-768",
+        "sig_primary": "ML-DSA-65",
+        "hash_primary": "SHA-256",
+        "requires_fips": True,
+        "citation": (
+            "NIST FIPS 203 (ML-KEM), FIPS 204 (ML-DSA), and FIPS 205 "
+            "(SLH-DSA) standardize the civilian PQC suite.  Hybrid is "
+            "permitted under SP 800-56C Rev. 2; it is not required."
+        ),
+        "source": (
+            "NIST FIPS 203 / 204 / 205, NIST IR 8547, "
+            "NIST SP 800-56C Rev. 2, NIST SP 800-227"
+        ),
+    },
+    "eu-anssi-bsi": {
+        "name": "ANSSI / BSI hybrid",
+        "authority": "ANSSI (FR) and BSI (DE) PQC migration guidance",
+        "hybrid_policy": "recommended",
+        "hybrid_allowed_for": [
+            "tls-server",
+            "tls-client",
+            "ikev2",
+            "signing-service",
+        ],
+        "kem_primary": "ML-KEM-768",
+        "sig_primary": "ML-DSA-65",
+        "hash_primary": "SHA-256",
+        "requires_fips": False,
+        "citation": (
+            "ANSSI and BSI both recommend deploying PQC alongside a "
+            "classical primitive (hybrid) during the migration period.  "
+            "Pure-PQC deployments are discouraged until confidence in "
+            "the new primitives matures."
+        ),
+        "source": "ANSSI position on PQC migration; BSI guidance on PQC",
+    },
+    "commercial": {
+        "name": "Commercial / no specific regime",
+        "authority": "no specific compliance regime",
+        "hybrid_policy": "either",
+        "hybrid_allowed_for": [
+            "tls-server",
+            "tls-client",
+            "ikev2",
+            "signing-service",
+        ],
+        "kem_primary": "ML-KEM-768",
+        "sig_primary": "ML-DSA-65",
+        "hash_primary": "SHA-256",
+        "requires_fips": False,
+        "citation": (
+            "Outside a specific compliance regime, both pure-PQC and "
+            "hybrid deployments are acceptable.  Hybrid is suggested "
+            "for data with long-confidentiality requirements (HNDL)."
+        ),
+        "source": "no single source — see policy guidance documentation",
+    },
+}
+
+VALID_POLICIES = ("cnsa-2.0", "nist-civilian", "eu-anssi-bsi", "commercial")
+VALID_ROLES = ("tls-server", "tls-client", "signing-service", "firmware-signing")
+
+
+def _accel_pqc_capable(accelerators: list[dict[str, Any]]) -> bool:
+    return any(a.get("pqc_capable") for a in (accelerators or []))
+
+
+def _isa_supports_large_params(isa_tier_str: str, has_pqc_accel: bool) -> bool:
+    """ISA tier 'excellent', or any tier with a PQC-capable accelerator,
+    can carry the larger parameter sets (ML-KEM-1024 / ML-DSA-87) at
+    typical service SLOs."""
+    return isa_tier_str == "excellent" or has_pqc_accel
+
+
+def _recommend_tls_server(r: Report, policy: str) -> dict[str, Any]:
+    pref = POLICY_PREFERENCES[policy]
+    isa = (r.isa_tier or "unknown").lower()
+    accel_pqc = _accel_pqc_capable(r.accelerators)
+    fips_kernel = bool((r.fips or {}).get("kernel"))
+    openssl = r.openssl or {}
+    tls_groups = openssl.get("tls_groups") or {}
+    hybrid_groups = list(tls_groups.get("hybrid") or [])
+    pure_groups = list(tls_groups.get("pure_pqc") or [])
+    openssl_version = openssl.get("version") or ""
+    kernel_release = (r.kernel_info or {}).get("release") or ""
+
+    caveats: list[str] = []
+
+    # KEM choice -----------------------------------------------------------
+    if policy == "cnsa-2.0":
+        kem_chosen = "ML-KEM-1024"
+        if _isa_supports_large_params(isa, accel_pqc):
+            kem_reason = (
+                "ML-KEM-1024 per CNSA 2.0; ISA tier and/or PQC accelerator "
+                "supports the larger parameter set"
+            )
+        else:
+            kem_reason = "ML-KEM-1024 mandated by CNSA 2.0"
+            caveats.append(
+                f"Policy mandates ML-KEM-1024 but host ISA tier is '{isa}' "
+                "and no PQC-capable accelerator is present; encapsulation "
+                "throughput will be lower than ML-KEM-768.  Add a PQC "
+                "accelerator or accept the slower path."
+            )
+    elif policy == "eu-anssi-bsi":
+        kem_chosen = "ML-KEM-768"
+        kem_reason = (
+            "ML-KEM-768 deployed in hybrid; ANSSI and BSI both recommend "
+            "hybrid during the migration period"
+        )
+    elif policy == "nist-civilian":
+        kem_chosen = "ML-KEM-768"
+        if _isa_supports_large_params(isa, accel_pqc):
+            kem_reason = (
+                "ML-KEM-768 per FIPS 203; ISA tier could support ML-KEM-1024 "
+                "if compliance scope demands it"
+            )
+        else:
+            kem_reason = (
+                "ML-KEM-768 per FIPS 203; balanced for civilian deployments"
+            )
+    else:  # commercial
+        kem_chosen = "ML-KEM-768"
+        kem_reason = (
+            "ML-KEM-768 — broadly interoperable default for commercial "
+            "deployments; consider hybrid for long-confidentiality data"
+        )
+
+    # Hybrid vs pure for the KEM ------------------------------------------
+    if pref["hybrid_policy"] == "recommended":
+        kem_mode = "hybrid"
+    elif pref["hybrid_policy"] == "discouraged":
+        # CNSA 2.0: pure preferred.  Hybrid is permitted only where the
+        # protocol mandates it (IKEv2).  TLS server is not IKEv2.
+        kem_mode = "pure"
+    else:
+        # nist-civilian / commercial: pure default; hybrid is permitted.
+        kem_mode = "pure"
+
+    # Capability check on advertised TLS 1.3 groups -----------------------
+    if openssl.get("available"):
+        if kem_mode == "hybrid" and not hybrid_groups:
+            caveats.append(
+                "No TLS 1.3 hybrid groups are advertised by this OpenSSL "
+                "build.  Upgrade OpenSSL or load the relevant provider "
+                "before deploying a hybrid TLS server."
+            )
+        elif kem_mode == "pure" and not pure_groups:
+            caveats.append(
+                "No TLS 1.3 pure-PQC groups are advertised by this "
+                "OpenSSL build.  Upgrade OpenSSL or load the relevant "
+                "provider before deploying pure-PQC TLS."
+            )
+    else:
+        caveats.append(
+            "OpenSSL was not detected on this host; the recommended "
+            "algorithms cannot be served via TLS until an OpenSSL build "
+            "with TLS 1.3 PQC group support is installed."
+        )
+
+    # Signature choice ----------------------------------------------------
+    if policy == "cnsa-2.0":
+        sig_chosen = "ML-DSA-87"
+        if _isa_supports_large_params(isa, accel_pqc):
+            sig_reason = (
+                "ML-DSA-87 per CNSA 2.0; ISA tier supports the signing "
+                "latency at typical service SLOs"
+            )
+        else:
+            sig_reason = "ML-DSA-87 mandated by CNSA 2.0"
+            caveats.append(
+                f"Policy mandates ML-DSA-87 but host ISA tier is '{isa}' "
+                "without a PQC accelerator; ML-DSA-87 sign p99 latency "
+                "may exceed typical service SLOs.  Consider a hardware "
+                "accelerator or accept the slower path."
+            )
+    else:
+        sig_chosen = "ML-DSA-65"
+        if isa == "good":
+            sig_reason = (
+                "ML-DSA-65 over ML-DSA-87 because ISA tier is 'good' not "
+                "'excellent'; ML-DSA-87 sign p99 latency will likely "
+                "exceed typical service SLOs"
+            )
+        elif isa in ("poor", "marginal", "adequate"):
+            sig_reason = (
+                f"ML-DSA-65 because ISA tier is '{isa}' without a PQC "
+                "accelerator; ML-DSA-87 sign p99 latency would likely "
+                "exceed typical SLOs"
+            )
+        elif isa == "excellent":
+            sig_reason = (
+                "ML-DSA-65 — balanced default for civilian/commercial "
+                "deployments; ISA tier could support ML-DSA-87 if "
+                "compliance scope demands it"
+            )
+        else:
+            sig_reason = (
+                "ML-DSA-65 — balanced default for civilian/commercial "
+                "deployments"
+            )
+
+    # Hash ----------------------------------------------------------------
+    hash_chosen = pref["hash_primary"]
+    hash_reason = f"{hash_chosen} aligned with {pref['name']} guidance"
+
+    # FIPS state caveats --------------------------------------------------
+    if pref["requires_fips"] and not fips_kernel:
+        caveats.append(
+            f"Kernel FIPS mode is not enabled.  {pref['name']} requires "
+            "use of FIPS-validated cryptographic modules; enable kernel "
+            "FIPS mode and load a FIPS-validated provider before going "
+            "to production."
+        )
+
+    # Build the recommendation record ------------------------------------
+    return {
+        "role": "tls-server",
+        "policy": policy,
+        "policy_authority": pref["authority"],
+        "policy_basis": pref["citation"],
+        "policy_source": pref["source"],
+        "implemented": True,
+        "kem": {
+            "algorithm": kem_chosen,
+            "mode": kem_mode,
+            "reason": kem_reason,
+        },
+        "signature": {
+            "algorithm": sig_chosen,
+            "reason": sig_reason,
+        },
+        "hash": {
+            "algorithm": hash_chosen,
+            "reason": hash_reason,
+        },
+        "host_capability_inputs": {
+            "isa_tier": isa,
+            "pqc_accelerator_present": accel_pqc,
+            "fips_kernel": fips_kernel,
+            "openssl_version": openssl_version,
+            "kernel_release": kernel_release,
+        },
+        "caveats": caveats,
+    }
+
+
+def _recommend_stub(r: Report, policy: str, role: str) -> dict[str, Any]:
+    """Placeholder for roles not yet fully implemented.  Returns the
+    policy basis so the JSON shape is consistent across roles, but
+    leaves the algorithm fields empty.
+
+    TODO(#13): expand to fully implement tls-client, signing-service,
+    and firmware-signing.  Each has its own SLO profile (e.g.,
+    firmware-signing tolerates SLH-DSA; tls-client cares about
+    handshake size more than throughput)."""
+    pref = POLICY_PREFERENCES[policy]
+    return {
+        "role": role,
+        "policy": policy,
+        "policy_authority": pref["authority"],
+        "policy_basis": pref["citation"],
+        "policy_source": pref["source"],
+        "implemented": False,
+        "note": (
+            f"Recommendations for role={role!r} are not yet implemented.  "
+            "Only role='tls-server' is supported in this revision."
+        ),
+        "host_capability_inputs": {
+            "isa_tier": (r.isa_tier or "unknown").lower(),
+            "pqc_accelerator_present": _accel_pqc_capable(r.accelerators),
+        },
+        "caveats": [],
+    }
+
+
+def _recommend_one(r: Report, policy: str, role: str) -> dict[str, Any]:
+    if role == "tls-server":
+        return _recommend_tls_server(r, policy)
+    return _recommend_stub(r, policy, role)
+
+
+def recommend(
+    r: Report,
+    policy: str = "auto",
+    role: str = "tls-server",
+) -> dict[str, Any]:
+    """Produce a host-specific PQC algorithm recommendation.
+
+    Pure function over (Report, policy, role).  Returns a record that
+    contains the recommendation AND the policy basis as separate fields,
+    so downstream tooling can audit the chain of reasoning without
+    re-deriving it.
+
+    policy='auto' emits one recommendation per real policy in
+    POLICY_PREFERENCES, side by side, with no single 'preferred' answer.
+    """
+    if role not in VALID_ROLES:
+        raise ValueError(
+            f"unknown role {role!r}; valid roles: {', '.join(VALID_ROLES)}"
+        )
+    if policy == "auto":
+        return {
+            "role": role,
+            "mode": "auto",
+            "hostname": r.hostname,
+            "generated_at": r.generated_at,
+            "recommendations": {
+                p: _recommend_one(r, p, role) for p in VALID_POLICIES
+            },
+        }
+    if policy not in POLICY_PREFERENCES:
+        raise ValueError(
+            f"unknown policy {policy!r}; valid policies: "
+            f"{', '.join(VALID_POLICIES)} (or 'auto')"
+        )
+    return {
+        "role": role,
+        "mode": "single",
+        "policy": policy,
+        "hostname": r.hostname,
+        "generated_at": r.generated_at,
+        "recommendations": {policy: _recommend_one(r, policy, role)},
+    }
+
+
+def _render_recommendation_block(rec: dict[str, Any]) -> list[str]:
+    """Render a single per-policy recommendation as plain-text lines."""
+    L: list[str] = []
+    L.append(f"Policy: {rec['policy']} ({rec['policy_authority']})")
+    if not rec.get("implemented", False):
+        L.append(f"  {rec.get('note', 'not implemented')}")
+        return L
+    kem = rec["kem"]
+    sig = rec["signature"]
+    h = rec["hash"]
+    L.append(f"  KEM:        {kem['algorithm']} ({kem['mode']})")
+    L.append(f"              Reason: {kem['reason']}")
+    L.append(f"  Signature:  {sig['algorithm']}")
+    L.append(f"              Reason: {sig['reason']}")
+    L.append(f"  Hash:       {h['algorithm']}")
+    L.append(f"              Reason: {h['reason']}")
+    L.append(f"  Policy basis: {rec['policy_basis']}")
+    L.append(f"  Source:       {rec['policy_source']}")
+    if rec["caveats"]:
+        L.append("  Caveats:")
+        for c in rec["caveats"]:
+            L.append(f"    - {c}")
+    return L
+
+
+def render_recommendation_text(report: Report, rec: dict[str, Any]) -> str:
+    L: list[str] = []
+    L.append(f"PQC algorithm recommendation — {report.hostname or 'unknown'}")
+    L.append(f"Role: {rec['role']}")
+    L.append(f"Mode: {rec['mode']}")
+    L.append("")
+    for _, sub in rec["recommendations"].items():
+        L.extend(_render_recommendation_block(sub))
+        L.append("")
+    return "\n".join(L).rstrip() + "\n"
+
+
+def render_recommendation_markdown(report: Report, rec: dict[str, Any]) -> str:
+    L: list[str] = []
+    L.append(f"# PQC algorithm recommendation — {report.hostname or 'unknown'}")
+    L.append("")
+    L.append(f"_Generated {report.generated_at}_")
+    L.append("")
+    L.append(f"**Role:** `{rec['role']}` &nbsp;·&nbsp; **Mode:** `{rec['mode']}`")
+    L.append("")
+    for _, sub in rec["recommendations"].items():
+        L.append(f"## Policy: `{sub['policy']}` — {sub['policy_authority']}")
+        L.append("")
+        if not sub.get("implemented", False):
+            L.append(f"> {sub.get('note', 'not implemented')}")
+            L.append("")
+            continue
+        kem = sub["kem"]
+        sig = sub["signature"]
+        h = sub["hash"]
+        L.append("| Primitive | Algorithm | Reason |")
+        L.append("|-----------|-----------|--------|")
+        L.append(f"| KEM ({kem['mode']}) | `{kem['algorithm']}` | {kem['reason']} |")
+        L.append(f"| Signature | `{sig['algorithm']}` | {sig['reason']} |")
+        L.append(f"| Hash | `{h['algorithm']}` | {h['reason']} |")
+        L.append("")
+        L.append(f"**Policy basis:** {sub['policy_basis']}")
+        L.append("")
+        L.append(f"**Source:** {sub['policy_source']}")
+        L.append("")
+        if sub["caveats"]:
+            L.append("**Caveats:**")
+            L.append("")
+            for c in sub["caveats"]:
+                L.append(f"- {c}")
+            L.append("")
+    return "\n".join(L).rstrip() + "\n"
+
+
+# ---------------------------------------------------------------------------
 # Renderers
 # ---------------------------------------------------------------------------
 
@@ -3742,6 +4201,32 @@ def main() -> int:
         help="emit {ansible_facts: {pqc_readiness: ...}} JSON, exit 0",
     )
     ap.add_argument(
+        "--recommend",
+        action="store_true",
+        help=(
+            "emit a host-specific PQC algorithm recommendation under the "
+            "selected policy and role, instead of the readiness report"
+        ),
+    )
+    ap.add_argument(
+        "--policy",
+        choices=[*VALID_POLICIES, "auto"],
+        default="auto",
+        help=(
+            "compliance context for --recommend; 'auto' (default) emits "
+            "all policies side by side"
+        ),
+    )
+    ap.add_argument(
+        "--role",
+        choices=list(VALID_ROLES),
+        default="tls-server",
+        help=(
+            "role for --recommend (only 'tls-server' is fully implemented; "
+            "other roles return a stub response)"
+        ),
+    )
+    ap.add_argument(
         "--aggregate",
         metavar="DIR",
         help="aggregate every *.json in DIR into a fleet rollup; exits when done",
@@ -3911,6 +4396,15 @@ def main() -> int:
         # ansible_facts wrapper.  The task must always exit 0 or Ansible
         # will mark the play as failed regardless of the report content.
         print(json.dumps({"ansible_facts": {"pqc_readiness": asdict(r)}}, indent=2))
+        return 0
+    if args.recommend:
+        rec = recommend(r, policy=args.policy, role=args.role)
+        if args.json:
+            print(json.dumps(rec, indent=2))
+        elif args.markdown:
+            print(render_recommendation_markdown(r, rec))
+        else:
+            print(render_recommendation_text(r, rec))
         return 0
     if args.json:
         print(json.dumps(asdict(r), indent=2))

--- a/tests/test_recommendation.py
+++ b/tests/test_recommendation.py
@@ -1,0 +1,327 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the algorithm recommendation engine.
+
+`recommend()` is a pure function over (Report, policy, role).  We
+construct synthetic Report values for three host capability profiles —
+excellent ISA, good ISA, poor ISA without an accelerator — and confirm
+that the recommendation differs across the four policies in the
+expected ways.
+
+Acceptance criteria source: issue #13 (algorithm recommendation engine)
+and `docs/recommendation-policies.md`.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+import pqc_readiness as pr
+
+ALL_POLICIES = ("cnsa-2.0", "nist-civilian", "eu-anssi-bsi", "commercial")
+
+
+def _make_report(
+    isa_tier: str = "excellent",
+    accelerators: list[dict[str, Any]] | None = None,
+    fips_kernel: bool = True,
+    openssl_available: bool = True,
+    hybrid_groups: list[str] | None = None,
+    pure_groups: list[str] | None = None,
+) -> pr.Report:
+    """Build a synthetic Report with only the fields the recommendation
+    engine consumes.  Detection-layer fields outside the engine's input
+    set are left at their dataclass defaults."""
+    return pr.Report(
+        hostname="test.example",
+        generated_at="2026-04-28T12:00:00+00:00",
+        os="Test OS",
+        arch="x86_64",
+        isa_tier=isa_tier,
+        accelerators=accelerators or [],
+        fips={"kernel": fips_kernel, "openssl_provider": fips_kernel},
+        openssl={
+            "available": openssl_available,
+            "version": "3.5.5",
+            "tls_groups": {
+                "hybrid": hybrid_groups
+                if hybrid_groups is not None
+                else ["X25519MLKEM768"],
+                "pure_pqc": pure_groups
+                if pure_groups is not None
+                else ["MLKEM768", "MLKEM1024"],
+            },
+        },
+        kernel_info={"release": "6.12.0-test"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Three host capability profiles × four policies — primary algorithm choice
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "isa_tier",
+    ["excellent", "good", "poor"],
+    ids=["excellent-isa", "good-isa", "poor-isa-no-accel"],
+)
+def test_cnsa_2_0_picks_ml_kem_1024_and_ml_dsa_87(isa_tier: str) -> None:
+    """CNSA 2.0 mandates ML-KEM-1024 and ML-DSA-87 regardless of host
+    capability; weaker hosts get a caveat instead of a downgrade."""
+    r = _make_report(isa_tier=isa_tier)
+    rec = pr.recommend(r, policy="cnsa-2.0", role="tls-server")
+    sub = rec["recommendations"]["cnsa-2.0"]
+    assert sub["kem"]["algorithm"] == "ML-KEM-1024"
+    assert sub["kem"]["mode"] == "pure"
+    assert sub["signature"]["algorithm"] == "ML-DSA-87"
+    assert sub["hash"]["algorithm"] == "SHA-384"
+    if isa_tier in ("good", "poor"):
+        assert any("ML-KEM-1024" in c for c in sub["caveats"])
+        assert any("ML-DSA-87" in c for c in sub["caveats"])
+    else:
+        assert all("mandates" not in c for c in sub["caveats"])
+
+
+@pytest.mark.parametrize("isa_tier", ["excellent", "good", "poor"])
+def test_nist_civilian_picks_ml_kem_768_pure(isa_tier: str) -> None:
+    r = _make_report(isa_tier=isa_tier)
+    rec = pr.recommend(r, policy="nist-civilian", role="tls-server")
+    sub = rec["recommendations"]["nist-civilian"]
+    assert sub["kem"]["algorithm"] == "ML-KEM-768"
+    assert sub["kem"]["mode"] == "pure"
+    assert sub["signature"]["algorithm"] == "ML-DSA-65"
+    assert sub["hash"]["algorithm"] == "SHA-256"
+
+
+@pytest.mark.parametrize("isa_tier", ["excellent", "good", "poor"])
+def test_eu_anssi_bsi_picks_hybrid(isa_tier: str) -> None:
+    r = _make_report(isa_tier=isa_tier)
+    rec = pr.recommend(r, policy="eu-anssi-bsi", role="tls-server")
+    sub = rec["recommendations"]["eu-anssi-bsi"]
+    assert sub["kem"]["algorithm"] == "ML-KEM-768"
+    assert sub["kem"]["mode"] == "hybrid"
+    assert sub["signature"]["algorithm"] == "ML-DSA-65"
+    assert sub["hash"]["algorithm"] == "SHA-256"
+
+
+@pytest.mark.parametrize("isa_tier", ["excellent", "good", "poor"])
+def test_commercial_picks_pure_ml_kem_768(isa_tier: str) -> None:
+    r = _make_report(isa_tier=isa_tier)
+    rec = pr.recommend(r, policy="commercial", role="tls-server")
+    sub = rec["recommendations"]["commercial"]
+    assert sub["kem"]["algorithm"] == "ML-KEM-768"
+    assert sub["kem"]["mode"] == "pure"
+    assert sub["signature"]["algorithm"] == "ML-DSA-65"
+    assert sub["hash"]["algorithm"] == "SHA-256"
+
+
+# ---------------------------------------------------------------------------
+# Cross-policy contrasts — recommendations must differ as expected
+# ---------------------------------------------------------------------------
+
+
+def test_recommendations_differ_across_policies_for_same_host() -> None:
+    """The same host must produce different recommendations under each
+    policy: this is the central premise of the recommendation engine."""
+    r = _make_report(isa_tier="excellent")
+    rec = pr.recommend(r, policy="auto", role="tls-server")
+    by_policy = rec["recommendations"]
+    cnsa = by_policy["cnsa-2.0"]
+    nist = by_policy["nist-civilian"]
+    anssi = by_policy["eu-anssi-bsi"]
+    comm = by_policy["commercial"]
+
+    # CNSA 2.0 vs. NIST civilian: parameter set differs (1024 vs. 768),
+    # signature differs (ML-DSA-87 vs. ML-DSA-65).
+    assert cnsa["kem"]["algorithm"] != nist["kem"]["algorithm"]
+    assert cnsa["signature"]["algorithm"] != nist["signature"]["algorithm"]
+
+    # ANSSI/BSI vs. NIST civilian: same algorithm, different mode.
+    assert anssi["kem"]["algorithm"] == nist["kem"]["algorithm"]
+    assert anssi["kem"]["mode"] == "hybrid"
+    assert nist["kem"]["mode"] == "pure"
+
+    # Commercial vs. NIST civilian: same KEM, but FIPS-required differs
+    # (commercial does not flag a FIPS caveat when FIPS is off).
+    r2 = _make_report(isa_tier="excellent", fips_kernel=False)
+    rec2 = pr.recommend(r2, policy="auto", role="tls-server")
+    assert any(
+        "FIPS" in c
+        for c in rec2["recommendations"]["nist-civilian"]["caveats"]
+    )
+    assert all(
+        "FIPS" not in c
+        for c in rec2["recommendations"]["commercial"]["caveats"]
+    )
+    assert all(
+        "FIPS" not in c
+        for c in rec2["recommendations"]["eu-anssi-bsi"]["caveats"]
+    )
+
+    # Commercial mode on the original host should be pure.
+    assert comm["kem"]["mode"] == "pure"
+
+
+# ---------------------------------------------------------------------------
+# Caveats: ISA tier conflicts with policy preference, FIPS missing, etc.
+# ---------------------------------------------------------------------------
+
+
+def test_cnsa_2_0_excellent_isa_no_isa_caveat() -> None:
+    r = _make_report(isa_tier="excellent")
+    sub = pr.recommend(r, "cnsa-2.0", "tls-server")["recommendations"]["cnsa-2.0"]
+    # No ISA-tier caveat when host can support the larger params.
+    assert all("host ISA tier" not in c for c in sub["caveats"])
+
+
+def test_cnsa_2_0_poor_isa_emits_isa_caveat() -> None:
+    r = _make_report(isa_tier="poor")
+    sub = pr.recommend(r, "cnsa-2.0", "tls-server")["recommendations"]["cnsa-2.0"]
+    assert any("host ISA tier is 'poor'" in c for c in sub["caveats"])
+
+
+def test_pqc_accelerator_softens_isa_caveat() -> None:
+    """A PQC-capable accelerator removes the ISA-tier caveat under
+    CNSA 2.0 even when ISA tier is poor."""
+    r = _make_report(
+        isa_tier="poor",
+        accelerators=[
+            {"kind": "hsm", "name": "test", "detail": "x", "pqc_capable": True}
+        ],
+    )
+    sub = pr.recommend(r, "cnsa-2.0", "tls-server")["recommendations"]["cnsa-2.0"]
+    assert all("host ISA tier" not in c for c in sub["caveats"])
+    assert sub["host_capability_inputs"]["pqc_accelerator_present"] is True
+
+
+def test_fips_off_emits_caveat_for_cnsa_and_nist() -> None:
+    r = _make_report(isa_tier="excellent", fips_kernel=False)
+    cnsa_caveats = pr.recommend(r, "cnsa-2.0", "tls-server")[
+        "recommendations"
+    ]["cnsa-2.0"]["caveats"]
+    nist_caveats = pr.recommend(r, "nist-civilian", "tls-server")[
+        "recommendations"
+    ]["nist-civilian"]["caveats"]
+    assert any("FIPS" in c for c in cnsa_caveats)
+    assert any("FIPS" in c for c in nist_caveats)
+
+
+def test_missing_hybrid_groups_caveat_under_anssi_bsi() -> None:
+    r = _make_report(isa_tier="excellent", hybrid_groups=[])
+    sub = pr.recommend(r, "eu-anssi-bsi", "tls-server")[
+        "recommendations"
+    ]["eu-anssi-bsi"]
+    assert any("hybrid groups" in c for c in sub["caveats"])
+
+
+def test_missing_pure_groups_caveat_under_cnsa() -> None:
+    r = _make_report(isa_tier="excellent", pure_groups=[])
+    sub = pr.recommend(r, "cnsa-2.0", "tls-server")["recommendations"]["cnsa-2.0"]
+    assert any("pure-PQC groups" in c for c in sub["caveats"])
+
+
+def test_openssl_unavailable_emits_caveat() -> None:
+    r = _make_report(isa_tier="excellent", openssl_available=False)
+    sub = pr.recommend(r, "commercial", "tls-server")[
+        "recommendations"
+    ]["commercial"]
+    assert any("OpenSSL was not detected" in c for c in sub["caveats"])
+
+
+# ---------------------------------------------------------------------------
+# Auto mode and role handling
+# ---------------------------------------------------------------------------
+
+
+def test_auto_mode_emits_all_four_policies() -> None:
+    r = _make_report()
+    rec = pr.recommend(r, policy="auto", role="tls-server")
+    assert rec["mode"] == "auto"
+    assert set(rec["recommendations"].keys()) == set(ALL_POLICIES)
+    for sub in rec["recommendations"].values():
+        assert sub["implemented"] is True
+
+
+def test_unknown_policy_raises() -> None:
+    r = _make_report()
+    with pytest.raises(ValueError, match="unknown policy"):
+        pr.recommend(r, policy="not-a-policy", role="tls-server")
+
+
+def test_unknown_role_raises() -> None:
+    r = _make_report()
+    with pytest.raises(ValueError, match="unknown role"):
+        pr.recommend(r, policy="commercial", role="not-a-role")
+
+
+@pytest.mark.parametrize(
+    "role", ["tls-client", "signing-service", "firmware-signing"]
+)
+def test_other_roles_return_stub(role: str) -> None:
+    r = _make_report()
+    rec = pr.recommend(r, policy="commercial", role=role)
+    sub = rec["recommendations"]["commercial"]
+    assert sub["implemented"] is False
+    assert sub["role"] == role
+    assert "not yet implemented" in sub["note"]
+
+
+# ---------------------------------------------------------------------------
+# Renderers and output shape
+# ---------------------------------------------------------------------------
+
+
+def test_json_output_shape_is_stable() -> None:
+    """Audit-trail consumers depend on the recommendation and policy
+    basis being separate top-level fields per sub-record."""
+    r = _make_report(isa_tier="excellent")
+    rec = pr.recommend(r, "cnsa-2.0", "tls-server")
+    # Recommendation must round-trip through JSON without loss.
+    parsed = json.loads(json.dumps(rec))
+    sub = parsed["recommendations"]["cnsa-2.0"]
+    assert {
+        "role",
+        "policy",
+        "policy_authority",
+        "policy_basis",
+        "policy_source",
+        "implemented",
+        "kem",
+        "signature",
+        "hash",
+        "host_capability_inputs",
+        "caveats",
+    }.issubset(sub.keys())
+
+
+def test_text_renderer_includes_policy_and_algorithm() -> None:
+    r = _make_report(isa_tier="excellent")
+    rec = pr.recommend(r, "cnsa-2.0", "tls-server")
+    out = pr.render_recommendation_text(r, rec)
+    assert "ML-KEM-1024" in out
+    assert "ML-DSA-87" in out
+    assert "cnsa-2.0" in out
+    assert "Policy basis:" in out
+
+
+def test_markdown_renderer_includes_policy_and_algorithm() -> None:
+    r = _make_report(isa_tier="excellent")
+    rec = pr.recommend(r, "auto", "tls-server")
+    out = pr.render_recommendation_markdown(r, rec)
+    assert "# PQC algorithm recommendation" in out
+    for policy in ALL_POLICIES:
+        assert f"`{policy}`" in out
+    assert "ML-KEM-1024" in out
+    assert "ML-KEM-768" in out
+
+
+def test_policy_preferences_are_documented() -> None:
+    """Every policy must declare an authority and a citation; the
+    citation is the audit hook for downstream tooling."""
+    for name in ALL_POLICIES:
+        pref = pr.POLICY_PREFERENCES[name]
+        assert pref["authority"], f"{name} missing authority"
+        assert pref["citation"], f"{name} missing citation"
+        assert pref["source"], f"{name} missing source"


### PR DESCRIPTION
Closes #13

## Summary

Adds a host-specific PQC algorithm recommendation engine. The
readiness report tells operators what their host *can* do; this
recommendation tells them what to *configure* given a compliance
context.

Different cryptographic authorities (NSA / CNSA 2.0, NIST, ANSSI, BSI)
take materially different positions on hybrid vs. pure-PQC preference,
so a single hardcoded recommendation is wrong for most users
regardless of what it says. The engine resolves that by taking the
compliance regime as an explicit input.

## Design

The engine is a pure function over `(Report, policy, role)`.

- `POLICY_PREFERENCES` is a single declarative dict of policy →
  preferences. Updating an authority position is a one-place edit.
- `_recommend_tls_server` consumes ISA tier, accelerator presence,
  FIPS state, and OpenSSL TLS group advertisement to choose
  algorithms and emit caveats where policy and host capability
  conflict.
- Other roles (`tls-client`, `signing-service`, `firmware-signing`)
  return a stub `{"implemented": False, ...}` per the issue scope.

## CLI

- `--recommend`: emit recommendation instead of readiness report
- `--policy {cnsa-2.0,nist-civilian,eu-anssi-bsi,commercial,auto}`
  (default `auto` — side-by-side under all four real policies)
- `--role {tls-server,tls-client,signing-service,firmware-signing}`
  (default `tls-server`)
- Combine with `--json` or `--markdown` for non-text output. JSON
  records carry the recommendation and the policy basis as separate
  fields so downstream tooling can audit the chain of reasoning.

## Documentation

`docs/recommendation-policies.md` cites the authoritative source for
each policy (NSA CNSA 2.0 advisory + FAQ; NIST FIPS 203/204/205, IR
8547, SP 800-56C Rev. 2, SP 800-227; ANSSI / BSI hybrid guidance) and
explains the maintenance flow when an authority revises guidance.

## Tests

30 new tests covering:

- All four policies × three host capability profiles (excellent,
  good, poor-no-accel). Each profile produces the expected primary
  algorithm under each policy.
- Cross-policy contrast: same host produces different recommendations
  under each policy.
- Caveats: ISA-tier conflict under CNSA 2.0; FIPS off; missing
  hybrid/pure TLS groups; OpenSSL absent.
- Auto mode emits all four policies; unknown policy/role raise.
- JSON/text/markdown renderers carry policy basis and algorithm.

Full suite: 163 / 163 pass.

## Test plan

- [x] `pytest` — 163 / 163 pass
- [x] `bash scripts/check-no-third-party-refs.sh` — clean
- [x] `cr --plain --type uncommitted` — no findings
- [x] `pqc-readiness --recommend --policy cnsa-2.0 --role tls-server` — outputs as expected
- [x] `pqc-readiness --recommend --json` — auto mode, four policies side-by-side