### PR TITLE
feat(bench): add --bench-tls loopback TLS 1.3 handshake benchmark

### DIFF
--- a/pqc_readiness.py
+++ b/pqc_readiness.py
@@ -19,6 +19,7 @@ Usage:
     pqc-readiness --cbom                    CycloneDX 1.6 CBOM JSON (NIST IR 8547)
     pqc-readiness --markdown                markdown report (for tickets)
     pqc-readiness --bench                   run PQC + classical microbench
+    pqc-readiness --bench-tls               run loopback TLS 1.3 handshake bench
     pqc-readiness --threads N               include N-way scaling test
     pqc-readiness --check TIER              exit nonzero if verdict < TIER
     pqc-readiness --check cnsa-2.0          exit nonzero if not CNSA 2.0 compliant
@@ -43,10 +44,14 @@ import json
 import os
 import platform
 import re
+import select
 import shutil
 import socket
+import statistics
 import subprocess
 import sys
+import tempfile
+import threading
 import time
 import uuid
 from dataclasses import asdict, dataclass, field
@@ -405,6 +410,7 @@ class Report:
     replace_required: bool = False
     os_release: dict[str, Any] = field(default_factory=dict)
     benchmark: dict[str, Any] = field(default_factory=dict)
+    benchmark_tls_handshake: dict[str, Any] = field(default_factory=dict)
     pqc_sizes: dict[str, dict[str, Any]] = field(default_factory=lambda: PQC_SIZES)
     per_algo: dict[str, dict[str, Any]] = field(default_factory=dict)
     production_estimate: dict[str, Any] = field(default_factory=dict)
@@ -2607,6 +2613,500 @@ def run_benchmarks(seconds: int = 1, threads: int = 1) -> dict[str, Any]:
     }
 
 
+# ---------------------------------------------------------------------------
+# TLS-handshake benchmark
+#
+# `openssl speed` measures algorithm operations in isolation; it does not
+# capture the network-side cost of larger PQC keys and signatures (cert
+# chain inflation, initcwnd overflow) that only shows up at the handshake
+# layer specified in RFC 8446.  This benchmark drives `openssl s_server`
+# and `openssl s_client` over loopback so the wire-side bandwidth impact
+# becomes visible alongside the algorithm-level numbers.
+# ---------------------------------------------------------------------------
+
+
+def _tls_pick_classical_group(classical: list[str]) -> str | None:
+    """Pick a sensible classical TLS 1.3 group for the baseline.
+
+    Prefer x25519 (modern default); fall back to secp256r1 if x25519 is
+    not exposed by the local OpenSSL.  Older curves (secp384r1, etc.)
+    are accepted only as a last resort so the comparison stays apples
+    to apples with the PQC suites.
+    """
+    lowered = {g.lower(): g for g in classical}
+    for pref in ("x25519", "secp256r1", "secp384r1"):
+        if pref in lowered:
+            return lowered[pref]
+    return classical[0] if classical else None
+
+
+def _tls_find_composite_signature_alg(sig_algs: list[str]) -> str | None:
+    """Detect a composite signature scheme exposed by the local OpenSSL.
+
+    Composite signatures (draft-ietf-lamps-pq-composite-sigs) bind a PQC
+    signature with a classical signature in a single key, providing a
+    hybrid hedge during PQC migration.  Only stock OpenSSL builds with
+    a provider exposing such names will return a non-None value.
+    Returns the OpenSSL algorithm name (suitable as `-newkey` arg) or
+    None if no composite scheme is available.
+    """
+    pat = re.compile(
+        r"^(?:id-)?(?:ml-?dsa)[-_]?\d+[-_]?"
+        r"(?:rsa\d*|p\d{3}|ecdsa[-_]?p\d{3}|ed25519|ed448)",
+        re.IGNORECASE,
+    )
+    for name in sig_algs:
+        if pat.match(name):
+            return name
+    return None
+
+
+def _tls_build_suites(osinfo: dict[str, Any]) -> list[dict[str, str]]:
+    """Pick the set of TLS group/cert configurations to benchmark.
+
+    Returns a list of suite descriptors with `label`, `role`, `group`,
+    and (optionally) `cert_signature_algorithm` keys.  Suites that are
+    not supported by the local OpenSSL are silently omitted.
+    """
+    groups = osinfo.get("tls_groups") or {}
+    suites: list[dict[str, str]] = []
+    classical = _tls_pick_classical_group(list(groups.get("classical") or []))
+    if classical:
+        suites.append(
+            {
+                "label": f"classical ({classical})",
+                "role": "classical",
+                "group": classical,
+            }
+        )
+    hybrid = list(groups.get("hybrid") or [])
+    pref_hybrid = next(
+        (g for g in hybrid if g.lower() in ("x25519mlkem768",)),
+        hybrid[0] if hybrid else None,
+    )
+    if pref_hybrid:
+        suites.append(
+            {"label": f"hybrid ({pref_hybrid})", "role": "hybrid", "group": pref_hybrid}
+        )
+    pure = list(groups.get("pure_pqc") or [])
+    pref_pure = next(
+        (g for g in pure if g.lower() in ("mlkem768",)),
+        pure[0] if pure else None,
+    )
+    if pref_pure:
+        suites.append(
+            {"label": f"pure-pqc ({pref_pure})", "role": "pure_pqc", "group": pref_pure}
+        )
+    return suites
+
+
+def _tls_get_free_port() -> int:
+    """Return a TCP port that is currently free on 127.0.0.1.
+
+    We close the probe socket before returning, so there is a small
+    race where another process could grab the port before s_server
+    binds.  In practice loopback contention on a CI runner is low
+    enough that this is not a problem in practice; we accept the race
+    rather than maintain a long-lived parent socket.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _tls_wait_for_port(port: int, timeout: float) -> bool:
+    """Poll-connect to 127.0.0.1:port until it accepts or timeout expires."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                return True
+        except OSError:
+            time.sleep(0.05)
+    return False
+
+
+def _tls_byte_counting_proxy(
+    listen_port: int,
+    target_port: int,
+    expected_connections: int,
+    accumulator: dict[str, int],
+    timeout: float,
+    ready_event: threading.Event,
+) -> None:
+    """Forward TCP between listen_port and target_port, counting bytes.
+
+    Runs in its own thread.  Accepts up to `expected_connections`
+    inbound connections (one per s_client invocation), forwards each to
+    target_port, and accumulates the total byte count in
+    accumulator['total'] with the connection count in accumulator['n'].
+    Sets ready_event once it is listening.
+    """
+    deadline = time.monotonic() + timeout
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        srv.bind(("127.0.0.1", listen_port))
+        srv.listen(max(expected_connections, 1))
+    except OSError:
+        ready_event.set()
+        srv.close()
+        return
+    ready_event.set()
+    accepted = 0
+    try:
+        while accepted < expected_connections and time.monotonic() < deadline:
+            srv.settimeout(max(0.1, deadline - time.monotonic()))
+            try:
+                client, _ = srv.accept()
+            except (socket.timeout, TimeoutError):
+                break
+            accepted += 1
+            try:
+                upstream = socket.create_connection(
+                    ("127.0.0.1", target_port), timeout=2.0
+                )
+            except OSError:
+                client.close()
+                continue
+            client.settimeout(None)
+            upstream.settimeout(None)
+            socks: list[socket.socket] = [client, upstream]
+            conn_bytes = 0
+            try:
+                while socks:
+                    rlist, _, _ = select.select(socks, [], [], 5.0)
+                    if not rlist:
+                        break
+                    closed = False
+                    for s in rlist:
+                        try:
+                            data = s.recv(8192)
+                        except OSError:
+                            data = b""
+                        if not data:
+                            closed = True
+                            break
+                        conn_bytes += len(data)
+                        peer = upstream if s is client else client
+                        try:
+                            peer.sendall(data)
+                        except OSError:
+                            closed = True
+                            break
+                    if closed:
+                        break
+            finally:
+                try:
+                    client.shutdown(socket.SHUT_RDWR)
+                except OSError:
+                    pass
+                try:
+                    upstream.shutdown(socket.SHUT_RDWR)
+                except OSError:
+                    pass
+                client.close()
+                upstream.close()
+            accumulator["total"] += conn_bytes
+            accumulator["n"] += 1
+    finally:
+        srv.close()
+
+
+def _tls_generate_test_cert(
+    cert: Path, key: Path, key_alg: str = "RSA:2048"
+) -> tuple[bool, str]:
+    """Create a self-signed loopback test cert.
+
+    Uses RSA-2048 by default since it is universally supported by
+    OpenSSL 3.x without requiring the EC subsystem.  Returns
+    (True, "") on success, (False, reason) on failure.
+    """
+    cmd = [
+        "openssl",
+        "req",
+        "-x509",
+        "-newkey",
+        key_alg,
+        "-keyout",
+        str(key),
+        "-out",
+        str(cert),
+        "-noenc",
+        "-subj",
+        "/CN=localhost",
+        "-addext",
+        "subjectAltName=DNS:localhost,IP:127.0.0.1",
+        "-days",
+        "1",
+    ]
+    rc, out = _run(cmd, timeout=20)
+    if rc != 0 or not cert.exists() or not key.exists():
+        return False, (out.strip().splitlines() or [f"rc={rc}"])[-1][:200]
+    return True, ""
+
+
+def _tls_run_one_handshake(
+    cert: Path, group: str, port: int, timeout: float = 10.0
+) -> float | None:
+    """Run a single full TLS handshake against 127.0.0.1:port via s_client.
+
+    Returns elapsed wall-clock seconds for the s_client invocation, or
+    None if the handshake failed.  Note: this measurement includes the
+    cost of spawning the openssl process; the relative comparison
+    between groups remains valid because spawn cost is constant.
+    """
+    cmd = [
+        "openssl",
+        "s_client",
+        "-connect",
+        f"127.0.0.1:{port}",
+        "-groups",
+        group,
+        "-CAfile",
+        str(cert),
+        "-verify_return_error",
+        "-quiet",
+        "-no_ign_eof",
+    ]
+    start = time.perf_counter()
+    try:
+        p = subprocess.run(
+            cmd,
+            input=b"GET / HTTP/1.0\r\n\r\n",
+            capture_output=True,
+            timeout=timeout,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    elapsed = time.perf_counter() - start
+    # `s_server -www` returns an HTTP 200 page and closes; s_client exits 0.
+    # Some OpenSSL builds exit non-zero on the server-side close even when
+    # the handshake succeeded, so we accept any exit code as long as the
+    # response payload is present.
+    if p.returncode != 0 and b"s_server" not in p.stdout:
+        return None
+    return elapsed
+
+
+def _tls_bench_one_suite(
+    cert: Path,
+    key: Path,
+    suite: dict[str, str],
+    iterations: int,
+    handshake_timeout: float = 10.0,
+) -> dict[str, Any]:
+    """Run `iterations` handshakes for one TLS suite and report metrics."""
+    server_port = _tls_get_free_port()
+    proxy_port = _tls_get_free_port()
+    while proxy_port == server_port:
+        proxy_port = _tls_get_free_port()
+    server_cmd = [
+        "openssl",
+        "s_server",
+        "-accept",
+        str(server_port),
+        "-cert",
+        str(cert),
+        "-key",
+        str(key),
+        "-groups",
+        suite["group"],
+        "-www",
+        "-no_ticket",
+        "-naccept",
+        str(iterations + 4),
+        "-quiet",
+    ]
+    try:
+        server = subprocess.Popen(
+            server_cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+    except OSError as exc:
+        return {"error": f"failed to spawn s_server: {exc}"}
+    try:
+        if not _tls_wait_for_port(server_port, timeout=5.0):
+            stderr = b""
+            try:
+                stderr = server.stderr.read() if server.stderr else b""
+            except OSError:
+                stderr = b""
+            return {
+                "error": "s_server failed to listen",
+                "detail": stderr.decode("utf-8", "replace").strip()[:200],
+            }
+        accumulator: dict[str, int] = {"total": 0, "n": 0}
+        ready = threading.Event()
+        proxy = threading.Thread(
+            target=_tls_byte_counting_proxy,
+            args=(
+                proxy_port,
+                server_port,
+                iterations,
+                accumulator,
+                handshake_timeout * iterations + 30.0,
+                ready,
+            ),
+            daemon=True,
+        )
+        proxy.start()
+        ready.wait(timeout=5.0)
+        if not _tls_wait_for_port(proxy_port, timeout=5.0):
+            return {"error": "byte-counting proxy failed to listen"}
+        times: list[float] = []
+        for _ in range(iterations):
+            t = _tls_run_one_handshake(
+                cert, suite["group"], proxy_port, timeout=handshake_timeout
+            )
+            if t is not None:
+                times.append(t)
+        proxy.join(timeout=10.0)
+    finally:
+        try:
+            server.terminate()
+            server.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            try:
+                server.kill()
+                server.wait(timeout=2)
+            except OSError:
+                pass
+        except OSError:
+            pass
+        if server.stderr:
+            try:
+                server.stderr.close()
+            except OSError:
+                pass
+    if not times:
+        return {"error": "no successful handshakes"}
+    total = sum(times)
+    bytes_per = (
+        round(accumulator["total"] / accumulator["n"])
+        if accumulator["n"] > 0
+        else None
+    )
+    return {
+        "iterations": len(times),
+        "handshakes_per_sec": round(len(times) / total, 2) if total > 0 else 0.0,
+        "ttfb_ms_mean": round(statistics.mean(times) * 1000.0, 3),
+        "ttfb_ms_median": round(statistics.median(times) * 1000.0, 3),
+        "bytes_on_wire_per_handshake": bytes_per,
+        "bytes_observed_connections": accumulator["n"],
+    }
+
+
+def _tls_bench_composite_signature(
+    tmpdir: Path,
+    osinfo: dict[str, Any],
+    iterations: int,
+) -> dict[str, Any] | None:
+    """Run the composite-signature variant of the suite, if available.
+
+    Composite signatures bind a PQC scheme with a classical scheme in a
+    single signing key (per draft-ietf-lamps-pq-composite-sigs).  Only
+    OpenSSL builds with a provider exposing such names can generate a
+    cert with a composite key; the function returns None when no such
+    algorithm is exposed or when cert generation fails.
+    """
+    sig_algs = list(osinfo.get("sig_algorithms") or [])
+    composite = _tls_find_composite_signature_alg(sig_algs)
+    if not composite:
+        return None
+    classical_group = _tls_pick_classical_group(
+        list((osinfo.get("tls_groups") or {}).get("classical") or [])
+    )
+    if not classical_group:
+        return None
+    cert = tmpdir / "cert-composite.pem"
+    key = tmpdir / "key-composite.pem"
+    ok, reason = _tls_generate_test_cert(cert, key, key_alg=composite)
+    if not ok:
+        return {
+            "label": f"composite-sig ({composite})",
+            "role": "composite_sig",
+            "group": classical_group,
+            "cert_signature_algorithm": composite,
+            "skipped": True,
+            "reason": f"cert generation failed: {reason}",
+        }
+    suite: dict[str, str] = {
+        "label": f"composite-sig ({composite})",
+        "role": "composite_sig",
+        "group": classical_group,
+        "cert_signature_algorithm": composite,
+    }
+    metrics = _tls_bench_one_suite(cert, key, suite, iterations)
+    return {**suite, **metrics}
+
+
+def run_tls_handshake_bench(
+    seconds: int, osinfo: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """Loopback TLS handshake benchmark across classical / hybrid / PQC.
+
+    Drives `openssl s_server` and `openssl s_client` over a Python
+    byte-counting proxy on 127.0.0.1.  Reports handshakes/sec, mean and
+    median time-to-first-byte (in milliseconds, including s_client
+    process startup), and bytes-on-wire per handshake for each
+    available TLS group selection plus an optional composite-signature
+    cert variant.
+    """
+    if not shutil.which("openssl"):
+        return {"available": False, "reason": "openssl not on PATH"}
+    rc, ver = _run(["openssl", "version"], timeout=5)
+    m = re.search(r"OpenSSL\s+(\d+)\.(\d+)", ver)
+    if not m or (int(m.group(1)), int(m.group(2))) < (3, 5):
+        return {
+            "available": False,
+            "reason": f"OpenSSL pre-3.5 lacks ML-KEM groups (got {ver.strip()})",
+        }
+    if osinfo is None:
+        osinfo = openssl_capability()
+    if not osinfo.get("available"):
+        return {"available": False, "reason": "openssl_capability probe failed"}
+    suites = _tls_build_suites(osinfo)
+    if not suites:
+        return {
+            "available": False,
+            "reason": "no TLS groups recognised by the local OpenSSL",
+        }
+    iterations = max(20, min(200, seconds * 30))
+    with tempfile.TemporaryDirectory(prefix="pqc-readiness-tls-") as td_str:
+        td = Path(td_str)
+        cert = td / "cert.pem"
+        key = td / "key.pem"
+        ok, reason = _tls_generate_test_cert(cert, key)
+        if not ok:
+            return {
+                "available": False,
+                "reason": f"failed to generate test cert: {reason}",
+            }
+        results: list[dict[str, Any]] = []
+        for s in suites:
+            metrics = _tls_bench_one_suite(cert, key, s, iterations)
+            results.append({**s, **metrics})
+        composite = _tls_bench_composite_signature(td, osinfo, iterations)
+        if composite is not None:
+            results.append(composite)
+    return {
+        "available": True,
+        "engine": "tls-handshake",
+        "transport": "loopback",
+        "openssl_version": (osinfo.get("version") or "").strip(),
+        "iterations_per_suite": iterations,
+        "seconds_budget": seconds,
+        "note": (
+            "ttfb measurements include the s_client process startup cost; "
+            "comparisons across groups are still meaningful because that "
+            "cost is constant"
+        ),
+        "suites": results,
+    }
+
+
 def memory_bandwidth_probe() -> tuple[float | None, str]:
     """STREAM-triad-style memory bandwidth probe (a = b * scalar + c).
 
@@ -3532,6 +4032,34 @@ def render_text(r: Report) -> str:
                     L.append(f"     {name:<10} {s}")
         L.append("")
 
+    if r.benchmark_tls_handshake:
+        L.append(C.wrap(C.BOLD, "6b. TLS handshake benchmark (loopback)"))
+        b = r.benchmark_tls_handshake
+        if not b.get("available"):
+            L.append(f"   unavailable: {b.get('reason')}")
+        else:
+            L.append(
+                f"   engine: {b.get('engine')}, transport: {b.get('transport')}, "
+                f"{b.get('iterations_per_suite')} handshakes/suite"
+            )
+            for s in b.get("suites") or []:
+                if "error" in s:
+                    L.append(f"   {s.get('label', s.get('role', '?')):<32} error: {s['error']}")
+                    continue
+                if s.get("skipped"):
+                    L.append(f"   {s.get('label', '?'):<32} skipped: {s.get('reason', '')}")
+                    continue
+                hps = s.get("handshakes_per_sec")
+                ttfb = s.get("ttfb_ms_median")
+                bw = s.get("bytes_on_wire_per_handshake")
+                L.append(
+                    f"   {s.get('label', '?'):<32} "
+                    f"{hps:>7.1f} hs/s  "
+                    f"ttfb={ttfb:>6.2f} ms  "
+                    f"wire={bw if bw is not None else '?'} B"
+                )
+        L.append("")
+
     if r.per_algo:
         L.append(C.wrap(C.BOLD, "7. Per-algorithm production verdict"))
         for key, v in r.per_algo.items():
@@ -3685,6 +4213,31 @@ def render_markdown(r: Report) -> str:
         for k, v in e.items():
             L.append(f"- {k}: {v}")
         L.append("")
+    if r.benchmark_tls_handshake.get("available"):
+        b = r.benchmark_tls_handshake
+        L.append("## TLS handshake benchmark (loopback)")
+        L.append(
+            f"_{b.get('iterations_per_suite')} handshakes per suite via "
+            f"`{b.get('openssl_version', 'openssl')}`. "
+            "ttfb includes s_client process startup._"
+        )
+        L.append("")
+        L.append("| Suite | Role | Handshakes/sec | TTFB median (ms) | Bytes on wire / handshake |")
+        L.append("|-------|------|---------------:|-----------------:|--------------------------:|")
+        for s in b.get("suites") or []:
+            if "error" in s:
+                L.append(f"| {s.get('label', '?')} | {s.get('role', '?')} | error | error | error |")
+                continue
+            if s.get("skipped"):
+                L.append(f"| {s.get('label', '?')} | {s.get('role', '?')} | skipped | skipped | skipped |")
+                continue
+            L.append(
+                f"| {s.get('label', '?')} | {s.get('role', '?')} | "
+                f"{s.get('handshakes_per_sec', '-')} | "
+                f"{s.get('ttfb_ms_median', '-')} | "
+                f"{s.get('bytes_on_wire_per_handshake', '-')} |"
+            )
+        L.append("")
     return "\n".join(L)
 
 
@@ -3707,6 +4260,11 @@ def main() -> int:
     )
     ap.add_argument(
         "--bench", action="store_true", help="run PQC + classical microbench"
+    )
+    ap.add_argument(
+        "--bench-tls",
+        action="store_true",
+        help="run loopback TLS 1.3 handshake benchmark (classical/hybrid/PQC)",
     )
     ap.add_argument("--threads", type=int, default=1, help="add an N-way scaling test")
     ap.add_argument("--seconds", type=int, default=1, help="seconds per benchmark op")
@@ -3826,11 +4384,14 @@ def main() -> int:
     hsm_present_but_not_pqc = hsm_present and not hsm_pqc_capable
 
     bench: dict[str, Any] = {}
+    bench_tls: dict[str, Any] = {}
     membw: float | None = None
     membw_method = ""
     if args.bench:
         bench = run_benchmarks(seconds=args.seconds, threads=max(args.threads, 1))
         membw, membw_method = memory_bandwidth_probe()
+    if args.bench_tls:
+        bench_tls = run_tls_handshake_bench(seconds=args.seconds, osinfo=osinfo)
 
     cores_for_estimate = physical or logical or 1
     tls_hybrid_avail = bool((osinfo.get("tls_groups") or {}).get("hybrid"))
@@ -3891,6 +4452,7 @@ def main() -> int:
         replace_required=replace_required,
         os_release=os_release,
         benchmark=bench,
+        benchmark_tls_handshake=bench_tls,
         per_algo=palg,
         production_estimate=pest,
         verdict=verdict,

--- a/tests/test_tls_bench.py
+++ b/tests/test_tls_bench.py
@@ -1,0 +1,246 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit and integration tests for the TLS-handshake benchmark.
+
+The pure helpers (suite selection, composite-signature detection) are
+exercised with synthetic inputs and don't need OpenSSL at all.  The
+end-to-end smoke test that actually drives `s_server` and `s_client`
+is gated on OpenSSL >= 3.5 with at least one ML-KEM TLS group exposed,
+which is the same precondition the production code checks.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import socket
+import subprocess
+from typing import Any
+
+import pytest
+
+import pqc_readiness as pr
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers — no external process required
+# ---------------------------------------------------------------------------
+
+
+def test_pick_classical_group_prefers_x25519() -> None:
+    assert pr._tls_pick_classical_group(["secp256r1", "x25519", "secp384r1"]) == "x25519"
+
+
+def test_pick_classical_group_falls_back_to_secp256r1() -> None:
+    assert pr._tls_pick_classical_group(["secp384r1", "secp256r1"]) == "secp256r1"
+
+
+def test_pick_classical_group_last_resort_returns_first_entry() -> None:
+    assert pr._tls_pick_classical_group(["ffdhe2048"]) == "ffdhe2048"
+
+
+def test_pick_classical_group_empty_returns_none() -> None:
+    assert pr._tls_pick_classical_group([]) is None
+
+
+def test_find_composite_signature_alg_matches_mldsa_rsa() -> None:
+    sigs = ["ML-DSA-65", "RSA-PSS", "id-MLDSA65-RSA3072-PSS-SHA512"]
+    assert pr._tls_find_composite_signature_alg(sigs) == "id-MLDSA65-RSA3072-PSS-SHA512"
+
+
+def test_find_composite_signature_alg_matches_oqs_naming() -> None:
+    sigs = ["mldsa65_p256", "ed25519"]
+    assert pr._tls_find_composite_signature_alg(sigs) == "mldsa65_p256"
+
+
+def test_find_composite_signature_alg_returns_none_for_pure_pqc() -> None:
+    assert pr._tls_find_composite_signature_alg(["ML-DSA-65", "ML-DSA-87"]) is None
+
+
+def test_build_suites_picks_classical_hybrid_pure_pqc() -> None:
+    osinfo: dict[str, Any] = {
+        "tls_groups": {
+            "classical": ["secp256r1", "x25519", "secp384r1"],
+            "hybrid": ["X25519MLKEM768", "SecP256r1MLKEM768"],
+            "pure_pqc": ["MLKEM512", "MLKEM768"],
+        }
+    }
+    suites = pr._tls_build_suites(osinfo)
+    roles = [s["role"] for s in suites]
+    assert roles == ["classical", "hybrid", "pure_pqc"]
+    classical, hybrid, pure = suites
+    assert classical["group"] == "x25519"
+    assert hybrid["group"] == "X25519MLKEM768"
+    assert pure["group"] == "MLKEM768"
+
+
+def test_build_suites_omits_unavailable_categories() -> None:
+    osinfo: dict[str, Any] = {
+        "tls_groups": {
+            "classical": ["x25519"],
+            "hybrid": [],
+            "pure_pqc": [],
+        }
+    }
+    suites = pr._tls_build_suites(osinfo)
+    assert len(suites) == 1
+    assert suites[0]["role"] == "classical"
+
+
+def test_build_suites_handles_missing_tls_groups_key() -> None:
+    assert pr._tls_build_suites({}) == []
+
+
+def test_build_suites_falls_back_when_preferred_hybrid_unavailable() -> None:
+    osinfo: dict[str, Any] = {
+        "tls_groups": {
+            "classical": ["x25519"],
+            "hybrid": ["SecP384r1MLKEM1024"],
+            "pure_pqc": ["MLKEM1024"],
+        }
+    }
+    suites = pr._tls_build_suites(osinfo)
+    hybrid = next(s for s in suites if s["role"] == "hybrid")
+    pure = next(s for s in suites if s["role"] == "pure_pqc")
+    assert hybrid["group"] == "SecP384r1MLKEM1024"
+    assert pure["group"] == "MLKEM1024"
+
+
+def test_get_free_port_returns_bindable_port() -> None:
+    port = pr._tls_get_free_port()
+    assert 0 < port < 65536
+    # Confirm the port is free at the moment we observed it.
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.bind(("127.0.0.1", port))
+
+
+def test_wait_for_port_returns_false_for_dead_port() -> None:
+    # _tls_get_free_port closes its probe socket, so this port is
+    # almost certainly unbound right now — that's the negative case.
+    port = pr._tls_get_free_port()
+    assert pr._tls_wait_for_port(port, timeout=0.3) is False
+
+
+# ---------------------------------------------------------------------------
+# run_tls_handshake_bench: graceful-skip dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_run_tls_handshake_bench_unavailable_when_openssl_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pr.shutil, "which", lambda _name: None)
+    out = pr.run_tls_handshake_bench(seconds=1)
+    assert out == {"available": False, "reason": "openssl not on PATH"}
+
+
+def test_run_tls_handshake_bench_unavailable_for_old_openssl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pr.shutil, "which", lambda _name: "/usr/bin/openssl")
+
+    def fake_run(cmd: list[str], timeout: int = 10) -> tuple[int, str]:
+        return 0, "OpenSSL 3.0.13 30 Jan 2024\n"
+
+    monkeypatch.setattr(pr, "_run", fake_run)
+    out = pr.run_tls_handshake_bench(seconds=1)
+    assert out["available"] is False
+    assert "pre-3.5" in out["reason"]
+
+
+def test_run_tls_handshake_bench_unavailable_when_no_groups(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pr.shutil, "which", lambda _name: "/usr/bin/openssl")
+
+    def fake_run(cmd: list[str], timeout: int = 10) -> tuple[int, str]:
+        return 0, "OpenSSL 3.5.5 27 Jan 2026\n"
+
+    monkeypatch.setattr(pr, "_run", fake_run)
+    out = pr.run_tls_handshake_bench(
+        seconds=1,
+        osinfo={"available": True, "tls_groups": {}},
+    )
+    assert out["available"] is False
+    assert "no TLS groups" in out["reason"]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end smoke test
+#
+# Skipped when OpenSSL is not present or pre-3.5, or when the local
+# OpenSSL has not been built with ML-KEM TLS groups.  On stock Fedora
+# 44 / OpenSSL 3.5+, this exercises the full s_server -> proxy ->
+# s_client path against a real loopback socket.
+# ---------------------------------------------------------------------------
+
+
+def _has_pqc_openssl() -> bool:
+    if not shutil.which("openssl"):
+        return False
+    try:
+        out = subprocess.run(
+            ["openssl", "version"], capture_output=True, text=True, timeout=5
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+    m = re.search(r"OpenSSL\s+(\d+)\.(\d+)", out.stdout)
+    if not m or (int(m.group(1)), int(m.group(2))) < (3, 5):
+        return False
+    cap = pr.openssl_capability()
+    groups = cap.get("tls_groups") or {}
+    return bool(groups.get("hybrid") or groups.get("pure_pqc") or groups.get("classical"))
+
+
+@pytest.mark.skipif(not _has_pqc_openssl(), reason="OpenSSL 3.5+ with TLS groups required")
+def test_run_tls_handshake_bench_end_to_end() -> None:
+    out = pr.run_tls_handshake_bench(seconds=1)
+    assert out["available"] is True
+    assert out["engine"] == "tls-handshake"
+    assert out["transport"] == "loopback"
+    assert isinstance(out["suites"], list) and out["suites"]
+    seen_classical = False
+    for s in out["suites"]:
+        assert "label" in s and "role" in s and "group" in s
+        if s["role"] == "classical":
+            seen_classical = True
+        if "error" in s or s.get("skipped"):
+            continue
+        assert s["iterations"] > 0
+        assert s["handshakes_per_sec"] > 0
+        assert s["ttfb_ms_median"] >= 0
+        # Bytes-on-wire is best-effort: the Python proxy may miss a
+        # connection on a slow CI runner, but the field must always
+        # be present and an int when populated.
+        if s.get("bytes_on_wire_per_handshake") is not None:
+            assert isinstance(s["bytes_on_wire_per_handshake"], int)
+            assert s["bytes_on_wire_per_handshake"] > 0
+    assert seen_classical, "classical baseline must always be measurable"
+
+
+@pytest.mark.skipif(not _has_pqc_openssl(), reason="OpenSSL 3.5+ with TLS groups required")
+def test_bench_tls_handshake_attaches_to_report_json(tmp_path: Any) -> None:
+    """Smoke-test the `--bench-tls` CLI flag end-to-end.
+
+    Runs the script with `--bench-tls --json --quiet` (quiet keeps stdout
+    short on green hosts) and confirms the resulting JSON has the
+    benchmark_tls_handshake field populated with engine = tls-handshake.
+    """
+    import json
+    import sys
+    from pathlib import Path
+
+    script = Path(pr.__file__)
+    proc = subprocess.run(
+        [sys.executable, str(script), "--bench-tls", "--json", "--seconds", "1"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert proc.returncode in (0, 1, 2, 3), proc.stderr
+    payload = json.loads(proc.stdout)
+    assert "benchmark_tls_handshake" in payload
+    bt = payload["benchmark_tls_handshake"]
+    assert bt.get("available") is True
+    assert bt.get("engine") == "tls-handshake"
+    assert isinstance(bt.get("suites"), list) and bt["suites"]


### PR DESCRIPTION
## Summary

Closes #12.

`openssl speed` (the existing `--bench`) measures algorithm operations in isolation. It misses the network-side cost of larger PQC keys and signatures — cert chain inflation, initcwnd overflow — that only shows up at the handshake layer specified in RFC 8446. Customer-impact prediction is materially better with handshake-level numbers.

`--bench-tls` drives `openssl s_server` and `openssl s_client` over a Python byte-counting proxy on 127.0.0.1, reporting:

- handshakes/sec
- mean and median time-to-first-byte (in milliseconds; includes s_client process startup, which is constant across groups)
- bytes-on-wire per handshake

…for each available TLS group selection — classical (x25519/secp256r1), hybrid (X25519MLKEM768), pure PQC (MLKEM768), plus a composite-signature cert variant when the local OpenSSL exposes one.

### Sample output (Fedora 44, OpenSSL 3.5.5)

```
6b. TLS handshake benchmark (loopback)
   engine: tls-handshake, transport: loopback, 30 handshakes/suite
   classical (x25519)                 289.5 hs/s  ttfb=  3.23 ms  wire=2029 B
   hybrid (X25519MLKEM768)            292.9 hs/s  ttfb=  3.21 ms  wire=4041 B
   pure-pqc (MLKEM768)                326.8 hs/s  ttfb=  2.93 ms  wire=4016 B
```

The wire-side cost inflation (2 KB → 4 KB) is exactly the metric the issue asked for, and would not be visible with `openssl speed`.

### Design notes

- The existing `--bench` is untouched. The new data attaches to the `Report` dataclass as `benchmark_tls_handshake` and is flagged `engine: "tls-handshake"` so JSON consumers can route on it without parsing the suite list.
- Text and markdown renderers gained a "TLS handshake benchmark" section that only appears when the bench actually ran, so every other code path remains byte-identical to before.
- Composite signatures aren't exposed by stock OpenSSL 3.5; the suite is skipped gracefully when no composite scheme is found in `openssl list -signature-algorithms`.
- The Python byte-counting proxy avoids dependence on `tcpdump`/`tshark` and keeps the only runtime requirement at OpenSSL 3.5+ on PATH.

### Out of scope (per the issue)

- Multi-host network benchmarks (loopback only)
- Realistic certificate chains beyond a generated test cert
- Network emulation for latency/loss

## Test plan

- [x] `make check` (ruff + mypy --strict + pytest) green locally
- [x] 18 new unit + integration tests in `tests/test_tls_bench.py`
- [x] End-to-end smoke test verifies real handshakes and wire-byte counts (gated on OpenSSL 3.5+)
- [x] `scripts/check-no-third-party-refs.sh` passes
- [x] CodeRabbit review: no findings
- [x] Manual `--bench-tls --json`, `--bench-tls --markdown`, plain text output verified
- [x] Confirmed `--bench` JSON shape unchanged when `--bench-tls` not passed