### PR TITLE
feat(detection): categorise trust-store certs as classical / hybrid_composite / pure_pqc

### DIFF
--- a/pqc_readiness.py
+++ b/pqc_readiness.py
@@ -1827,6 +1827,28 @@ HYBRID_OID_RES: list[re.Pattern[str]] = [
     re.compile(r"\b1\.3\.6\.1\.4\.1\.42235\.1\.7\.\d+\b"),  # Mozilla draft
     re.compile(r"\b1\.3\.9999\.\d+\.\d+\.\d+\b"),  # liboqs experimental
 ]
+# IETF composite signature OIDs (draft-ietf-lamps-pq-composite-sigs).
+# IANA early-allocated 2025-10-20 under the SMI Security PKIX Algorithms arc
+# 1.3.6.1.5.5.7.6.{37..54} — covers all 18 Composite-ML-DSA variants pairing
+# ML-DSA-44/65/87 with RSA, ECDSA, or EdDSA classical components.  These
+# certs use a single composite signature algorithm OID and form the
+# "hybrid_composite" category in trust_store.cert_categories.
+COMPOSITE_SIG_OID_RE = re.compile(r"\b1\.3\.6\.1\.5\.5\.7\.6\.(3[7-9]|4\d|5[0-4])\b")
+
+
+def categorise_cert_dump(dump: str) -> str:
+    """Categorise an openssl x509 -text dump as 'classical',
+    'hybrid_composite', or 'pure_pqc'.
+
+    Composite is checked before pure PQC because a composite-signature cert
+    typically advertises both the composite OID and the embedded ML-DSA OID
+    — the IETF composite category is the more specific (and accurate) label
+    for those certs."""
+    if COMPOSITE_SIG_OID_RE.search(dump):
+        return "hybrid_composite"
+    if PQC_OID_RE.search(dump):
+        return "pure_pqc"
+    return "classical"
 
 
 def scan_trust_store(dirs: list[str] | None = None) -> dict[str, Any]:
@@ -1836,6 +1858,11 @@ def scan_trust_store(dirs: list[str] | None = None) -> dict[str, Any]:
     total = 0
     pqc_certs = 0
     hybrid_certs = 0
+    cert_categories: dict[str, int] = {
+        "classical": 0,
+        "hybrid_composite": 0,
+        "pure_pqc": 0,
+    }
     seen: set[str] = set()
     for d in target_dirs:
         p = Path(d)
@@ -1869,12 +1896,14 @@ def scan_trust_store(dirs: list[str] | None = None) -> dict[str, Any]:
                 pqc_certs += 1
             if any(p.search(dump) for p in HYBRID_OID_RES):
                 hybrid_certs += 1
+            cert_categories[categorise_cert_dump(dump)] += 1
     return {
         "available": True,
         "scanned_dirs": [d for d in target_dirs if Path(d).is_dir()],
         "total_certs": total,
         "pqc_certs": pqc_certs,
         "hybrid_certs": hybrid_certs,
+        "cert_categories": cert_categories,
     }
 
 
@@ -2984,9 +3013,7 @@ def _tls_bench_one_suite(
         return {"error": "no successful handshakes"}
     total = sum(times)
     bytes_per = (
-        round(accumulator["total"] / accumulator["n"])
-        if accumulator["n"] > 0
-        else None
+        round(accumulator["total"] / accumulator["n"]) if accumulator["n"] > 0 else None
     )
     return {
         "iterations": len(times),
@@ -3529,9 +3556,7 @@ def _recommend_tls_server(r: Report, policy: str) -> dict[str, Any]:
                 "if compliance scope demands it"
             )
         else:
-            kem_reason = (
-                "ML-KEM-768 per FIPS 203; balanced for civilian deployments"
-            )
+            kem_reason = "ML-KEM-768 per FIPS 203; balanced for civilian deployments"
     else:  # commercial
         kem_chosen = "ML-KEM-768"
         kem_reason = (
@@ -3609,8 +3634,7 @@ def _recommend_tls_server(r: Report, policy: str) -> dict[str, Any]:
             )
         else:
             sig_reason = (
-                "ML-DSA-65 — balanced default for civilian/commercial "
-                "deployments"
+                "ML-DSA-65 — balanced default for civilian/commercial deployments"
             )
 
     # Hash ----------------------------------------------------------------
@@ -3718,9 +3742,7 @@ def recommend(
             "mode": "auto",
             "hostname": r.hostname,
             "generated_at": r.generated_at,
-            "recommendations": {
-                p: _recommend_one(r, p, role) for p in VALID_POLICIES
-            },
+            "recommendations": {p: _recommend_one(r, p, role) for p in VALID_POLICIES},
         }
     if policy not in POLICY_PREFERENCES:
         raise ValueError(
@@ -4228,6 +4250,14 @@ def _cbom_trust_store_assets(r: Report) -> list[dict[str, Any]]:
         {"name": "trust_store:pqc_certs", "value": str(ts.get("pqc_certs", 0))},
         {"name": "trust_store:hybrid_certs", "value": str(ts.get("hybrid_certs", 0))},
     ]
+    cats = ts.get("cert_categories") or {}
+    for cat in ("classical", "hybrid_composite", "pure_pqc"):
+        extra.append(
+            {
+                "name": f"trust_store:cert_categories:{cat}",
+                "value": str(cats.get(cat, 0)),
+            }
+        )
     for d in ts.get("scanned_dirs") or []:
         extra.append({"name": "trust_store:scanned_dir", "value": d})
     return [
@@ -4503,10 +4533,14 @@ def render_text(r: Report) -> str:
             )
             for s in b.get("suites") or []:
                 if "error" in s:
-                    L.append(f"   {s.get('label', s.get('role', '?')):<32} error: {s['error']}")
+                    L.append(
+                        f"   {s.get('label', s.get('role', '?')):<32} error: {s['error']}"
+                    )
                     continue
                 if s.get("skipped"):
-                    L.append(f"   {s.get('label', '?'):<32} skipped: {s.get('reason', '')}")
+                    L.append(
+                        f"   {s.get('label', '?'):<32} skipped: {s.get('reason', '')}"
+                    )
                     continue
                 hps = s.get("handshakes_per_sec")
                 ttfb = s.get("ttfb_ms_median")
@@ -4567,6 +4601,14 @@ def render_text(r: Report) -> str:
         L.append(f"   Total certs:      {r.trust_store.get('total_certs', 0)}")
         L.append(f"   PQC certs:        {r.trust_store.get('pqc_certs', 0)}")
         L.append(f"   Hybrid certs:     {r.trust_store.get('hybrid_certs', 0)}")
+        cats = r.trust_store.get("cert_categories") or {}
+        if cats:
+            L.append(
+                "   Categories:       "
+                f"classical={cats.get('classical', 0)}, "
+                f"hybrid_composite={cats.get('hybrid_composite', 0)}, "
+                f"pure_pqc={cats.get('pure_pqc', 0)}"
+            )
         L.append("")
 
     if r.cnsa_2_0:
@@ -4681,14 +4723,22 @@ def render_markdown(r: Report) -> str:
             "ttfb includes s_client process startup._"
         )
         L.append("")
-        L.append("| Suite | Role | Handshakes/sec | TTFB median (ms) | Bytes on wire / handshake |")
-        L.append("|-------|------|---------------:|-----------------:|--------------------------:|")
+        L.append(
+            "| Suite | Role | Handshakes/sec | TTFB median (ms) | Bytes on wire / handshake |"
+        )
+        L.append(
+            "|-------|------|---------------:|-----------------:|--------------------------:|"
+        )
         for s in b.get("suites") or []:
             if "error" in s:
-                L.append(f"| {s.get('label', '?')} | {s.get('role', '?')} | error | error | error |")
+                L.append(
+                    f"| {s.get('label', '?')} | {s.get('role', '?')} | error | error | error |"
+                )
                 continue
             if s.get("skipped"):
-                L.append(f"| {s.get('label', '?')} | {s.get('role', '?')} | skipped | skipped | skipped |")
+                L.append(
+                    f"| {s.get('label', '?')} | {s.get('role', '?')} | skipped | skipped | skipped |"
+                )
                 continue
             L.append(
                 f"| {s.get('label', '?')} | {s.get('role', '?')} | "

--- a/tests/test_trust_store.py
+++ b/tests/test_trust_store.py
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for trust-store certificate categorisation.
+
+Covers the IETF composite-signature OID detection added to support
+classifying hybrid-composite certs separately from classical and pure
+PQC certs (issue #10)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pqc_readiness as pr
+
+
+# ---------------------------------------------------------------------------
+# categorise_cert_dump — pure unit tests
+# ---------------------------------------------------------------------------
+
+CLASSICAL_DUMP = """\
+Certificate:
+    Data:
+        Signature Algorithm: sha256WithRSAEncryption (1.2.840.113549.1.1.11)
+        Issuer: CN=Example RSA CA
+        Subject: CN=example.com
+"""
+
+PURE_PQC_DUMP = """\
+Certificate:
+    Data:
+        Signature Algorithm: id-ml-dsa-65 (2.16.840.1.101.3.4.3.18)
+        Issuer: CN=Example ML-DSA CA
+        Subject: CN=pqc.example.com
+"""
+
+# Composite-ML-DSA-44-ECDSA-P256-SHA256 (1.3.6.1.5.5.7.6.40).
+COMPOSITE_DUMP = """\
+Certificate:
+    Data:
+        Signature Algorithm: id-MLDSA44-ECDSA-P256-SHA256 (1.3.6.1.5.5.7.6.40)
+        Issuer: CN=Example Composite CA
+        Subject: CN=hybrid.example.com
+"""
+
+# Composite cert dumps typically also reference the embedded ML-DSA OID
+# (e.g. inside the SubjectPublicKeyInfo or the openssl debug output).
+# The categoriser must still pick `hybrid_composite`, not `pure_pqc`.
+COMPOSITE_DUMP_WITH_EMBEDDED_PQC = """\
+Certificate:
+    Data:
+        Signature Algorithm: id-MLDSA65-Ed25519-SHA512 (1.3.6.1.5.5.7.6.48)
+        Subject Public Key Info:
+            Public Key Algorithm: composite (embeds 2.16.840.1.101.3.4.3.18)
+"""
+
+
+def test_categorise_classical() -> None:
+    assert pr.categorise_cert_dump(CLASSICAL_DUMP) == "classical"
+
+
+def test_categorise_pure_pqc_ml_dsa() -> None:
+    assert pr.categorise_cert_dump(PURE_PQC_DUMP) == "pure_pqc"
+
+
+def test_categorise_pure_pqc_slh_dsa() -> None:
+    # SLH-DSA-SHAKE-256s OID 2.16.840.1.101.3.4.3.31 — top of the NIST PQC range.
+    dump = "Signature Algorithm: id-slh-dsa-shake-256s (2.16.840.1.101.3.4.3.31)"
+    assert pr.categorise_cert_dump(dump) == "pure_pqc"
+
+
+def test_categorise_composite_low_oid() -> None:
+    # Lowest assigned composite OID (.37 — id-MLDSA44-RSA2048-PSS-SHA256).
+    dump = "Signature Algorithm: id-MLDSA44-RSA2048-PSS-SHA256 (1.3.6.1.5.5.7.6.37)"
+    assert pr.categorise_cert_dump(dump) == "hybrid_composite"
+
+
+def test_categorise_composite_high_oid() -> None:
+    # Highest assigned composite OID (.54 — id-MLDSA87-ECDSA-P521-SHA512).
+    dump = "Signature Algorithm: id-MLDSA87-ECDSA-P521-SHA512 (1.3.6.1.5.5.7.6.54)"
+    assert pr.categorise_cert_dump(dump) == "hybrid_composite"
+
+
+def test_categorise_composite() -> None:
+    assert pr.categorise_cert_dump(COMPOSITE_DUMP) == "hybrid_composite"
+
+
+def test_categorise_composite_takes_precedence_over_pure_pqc() -> None:
+    # A composite cert dump that also mentions the embedded PQC OID must
+    # categorise as composite, not pure PQC — composite is the more
+    # specific (and correct) IETF category.
+    assert (
+        pr.categorise_cert_dump(COMPOSITE_DUMP_WITH_EMBEDDED_PQC) == "hybrid_composite"
+    )
+
+
+def test_oid_outside_composite_range_is_classical() -> None:
+    # Adjacent IANA SMI OIDs (e.g. .36 just below the composite range and
+    # .55 just above) must NOT match — they aren't composite signatures.
+    below = "Signature Algorithm: id-something (1.3.6.1.5.5.7.6.36)"
+    above = "Signature Algorithm: id-something (1.3.6.1.5.5.7.6.55)"
+    assert pr.categorise_cert_dump(below) == "classical"
+    assert pr.categorise_cert_dump(above) == "classical"
+
+
+def test_composite_oid_with_trailing_digit_does_not_falsely_match() -> None:
+    # Word-boundary anchor must reject e.g. `1.3.6.1.5.5.7.6.374` —
+    # the trailing `4` extends the leaf and the OID is not composite.
+    dump = "Signature Algorithm: id-something (1.3.6.1.5.5.7.6.374)"
+    assert pr.categorise_cert_dump(dump) == "classical"
+
+
+# ---------------------------------------------------------------------------
+# scan_trust_store integration — categorises real certs read via openssl
+# ---------------------------------------------------------------------------
+
+
+def _write_pem(path: Path, body: str = "fake") -> None:
+    path.write_text(f"-----BEGIN CERTIFICATE-----\n{body}\n-----END CERTIFICATE-----\n")
+
+
+def test_scan_trust_store_no_openssl(monkeypatch) -> None:
+    monkeypatch.setattr(pr.shutil, "which", lambda name: None)
+    result = pr.scan_trust_store(dirs=["/nonexistent"])
+    assert result == {"available": False, "reason": "openssl not on PATH"}
+
+
+def test_scan_trust_store_categorises_each_cert(monkeypatch, tmp_path) -> None:
+    # Three fake PEM files; we monkeypatch _run to return a dump matching
+    # each cert's filename so we exercise all three categories without
+    # needing a real composite-sig cert (which openssl can't yet sign).
+    classical = tmp_path / "classical.pem"
+    composite = tmp_path / "composite.pem"
+    pure_pqc = tmp_path / "pure_pqc.pem"
+    _write_pem(classical)
+    _write_pem(composite)
+    _write_pem(pure_pqc)
+
+    dumps_by_path: dict[str, str] = {
+        str(classical): CLASSICAL_DUMP,
+        str(composite): COMPOSITE_DUMP,
+        str(pure_pqc): PURE_PQC_DUMP,
+    }
+
+    monkeypatch.setattr(pr.shutil, "which", lambda name: "/usr/bin/openssl")
+
+    def fake_run(cmd, timeout=None):  # noqa: ARG001 — signature must match _run
+        # cmd is like ["openssl", "x509", "-in", <path>, ...]
+        path = cmd[cmd.index("-in") + 1]
+        return 0, dumps_by_path[path]
+
+    monkeypatch.setattr(pr, "_run", fake_run)
+
+    result = pr.scan_trust_store(dirs=[str(tmp_path)])
+
+    assert result["available"] is True
+    assert result["total_certs"] == 3
+    assert result["cert_categories"] == {
+        "classical": 1,
+        "hybrid_composite": 1,
+        "pure_pqc": 1,
+    }
+
+
+def test_scan_trust_store_skips_unreadable_certs(monkeypatch, tmp_path) -> None:
+    # If openssl returns a non-zero exit code for a cert, that cert must
+    # not be counted in either total_certs or any category.
+    good = tmp_path / "good.pem"
+    bad = tmp_path / "bad.pem"
+    _write_pem(good)
+    _write_pem(bad)
+
+    monkeypatch.setattr(pr.shutil, "which", lambda name: "/usr/bin/openssl")
+
+    def fake_run(cmd, timeout=None):  # noqa: ARG001
+        path = cmd[cmd.index("-in") + 1]
+        if path.endswith("bad.pem"):
+            return 1, ""
+        return 0, CLASSICAL_DUMP
+
+    monkeypatch.setattr(pr, "_run", fake_run)
+
+    result = pr.scan_trust_store(dirs=[str(tmp_path)])
+
+    assert result["total_certs"] == 1
+    assert result["cert_categories"]["classical"] == 1
+    assert result["cert_categories"]["hybrid_composite"] == 0
+    assert result["cert_categories"]["pure_pqc"] == 0
+
+
+def test_scan_trust_store_empty_when_no_dirs_match(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(pr.shutil, "which", lambda name: "/usr/bin/openssl")
+    result = pr.scan_trust_store(dirs=[str(tmp_path / "missing")])
+    assert result["total_certs"] == 0
+    assert result["cert_categories"] == {
+        "classical": 0,
+        "hybrid_composite": 0,
+        "pure_pqc": 0,
+    }


### PR DESCRIPTION
## Summary

- Adds IETF composite-signature OID detection to `scan_trust_store`
- Surfaces `trust_store.cert_categories = {classical, hybrid_composite, pure_pqc}` counts in the report and CBOM output
- 13 new tests covering the categoriser and `scan_trust_store` integration

## Why

Hybrid certs that bind a PQC scheme with a classical scheme via composite signatures (draft-ietf-lamps-pq-composite-sigs) will appear in customer trust stores during the transitional period before pure-PQC PKI rolls out. Lumping these in with pure ML-DSA certs obscures the distinction that drives deployment decisions.

## Implementation notes

- Matches the IETF composite arc `1.3.6.1.5.5.7.6.{37..54}` — IANA early-allocated 2025-10-20, covering all 18 Composite-ML-DSA variants pairing ML-DSA-44/65/87 with RSA, ECDSA, or EdDSA
- The composite check runs before the NIST PQC check because a composite-sig cert references both the composite OID and the embedded ML-DSA OID — the IETF composite label is the more specific category
- Existing `pqc_certs` / `hybrid_certs` counts remain unchanged so the OQS-style hybrid telemetry is not broken
- Word-boundary anchoring on the OID regex is verified by a dedicated test (rejects e.g. `1.3.6.1.5.5.7.6.374`)

## Test plan

- [x] `pytest tests/test_trust_store.py` — 13 new tests pass
- [x] `pytest` — full suite (194 tests) green
- [x] `scripts/check-no-third-party-refs.sh` — clean
- [x] `cr --plain --type uncommitted` — no findings
- [x] `pre-commit run` (ruff + ruff-format + mypy --strict + detect-secrets) — all green
- [ ] CI green on the PR

Closes #10