### PR TITLE
feat: SARIF 2.1.0 findings output (--sarif)

### DIFF
--- a/pqc_readiness.py
+++ b/pqc_readiness.py
@@ -17,6 +17,7 @@ Usage:
     pqc-readiness                           human-readable report
     pqc-readiness --json                    machine-readable (stable schema)
     pqc-readiness --cbom                    CycloneDX 1.6 CBOM JSON (NIST IR 8547)
+    pqc-readiness --sarif                   SARIF 2.1.0 findings (OASIS)
     pqc-readiness --markdown                markdown report (for tickets)
     pqc-readiness --bench                   run PQC + classical microbench
     pqc-readiness --bench-tls               run loopback TLS 1.3 handshake bench
@@ -4307,6 +4308,351 @@ def render_cbom(r: Report) -> str:
     return json.dumps(bom, indent=2)
 
 
+# ---------------------------------------------------------------------------
+# SARIF 2.1.0 finding output (--sarif)
+# ---------------------------------------------------------------------------
+# SARIF (Static Analysis Results Interchange Format, OASIS) is the standard
+# exchange format for code-scanning and security tooling.  Emitting SARIF
+# lets readiness output drop into existing security pipelines (CodeQL,
+# GitHub code scanning, IDE integrations) without per-tool adapters.
+#
+# This is host-level analysis, not file-level — every result attaches the
+# scanned host's identity (hostname, OS, arch, the values that triggered
+# the rule) under `result.properties` rather than file locations.  Per
+# SARIF 2.1.0 the only required result field is `message`; `locations` is
+# recommended but optional.
+#
+# Adding a new rule means appending one entry to RULE_SPECS plus a small
+# predicate in build_findings().
+
+SARIF_VERSION = "2.1.0"
+SARIF_SCHEMA_URI = "https://json.schemastore.org/sarif-2.1.0.json"
+SARIF_HELP_BASE = "https://github.com/aclater/pqc-readiness/blob/main/docs/rules"
+
+
+@dataclass(frozen=True)
+class RuleSpec:
+    """Static metadata for one SARIF rule.
+
+    `default_level` is the SARIF severity enum value: one of
+    ``error``, ``warning``, ``note``."""
+
+    id: str
+    short_description: str
+    full_description: str
+    default_level: str
+    help_uri: str
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One detected condition projected from Report state.
+
+    `properties` carries host-level context — the specific values that
+    triggered the rule — since SARIF results have no file location for
+    host-scope analysis."""
+
+    rule_id: str
+    level: str
+    message: str
+    properties: dict[str, Any]
+
+
+RULE_SPECS: tuple[RuleSpec, ...] = (
+    RuleSpec(
+        id="pqc-001-openssl-pre-3.5",
+        short_description="OpenSSL is older than 3.5 (no native PQC).",
+        full_description=(
+            "The host's OpenSSL is older than 3.5.0, which is the first "
+            "release with native ML-KEM and ML-DSA support.  Pre-3.5 "
+            "OpenSSL cannot expose PQC algorithms or hybrid TLS groups "
+            "to applications without a third-party provider."
+        ),
+        default_level="warning",
+        help_uri=f"{SARIF_HELP_BASE}/pqc-001-openssl-pre-3.5.md",
+    ),
+    RuleSpec(
+        id="pqc-002-fips-pqc-conflict",
+        short_description=(
+            "Kernel FIPS mode active but PQC exposed via non-FIPS provider."
+        ),
+        full_description=(
+            "Kernel FIPS mode is enabled and OpenSSL is exposing PQC "
+            "algorithms, but the FIPS provider does not yet include "
+            "ML-KEM or ML-DSA.  The algorithms appear listed yet would "
+            "not be usable in a FIPS-validated workflow."
+        ),
+        default_level="error",
+        help_uri=f"{SARIF_HELP_BASE}/pqc-002-fips-pqc-conflict.md",
+    ),
+    RuleSpec(
+        id="pqc-003-no-pqc-isa-support",
+        short_description=(
+            "ISA tier is poor and no PQC accelerator is present."
+        ),
+        full_description=(
+            "The host's ISA feature score is below the threshold for "
+            "software PQC, and no PQC-capable accelerator (HSM, network "
+            "HSM, or dedicated silicon) was detected.  The host cannot "
+            "be made PQC-ready in software alone."
+        ),
+        default_level="warning",
+        help_uri=f"{SARIF_HELP_BASE}/pqc-003-no-pqc-isa-support.md",
+    ),
+    RuleSpec(
+        id="pqc-004-classical-only-trust-store",
+        short_description=(
+            "Trust store contains zero PQC and zero hybrid certificates."
+        ),
+        full_description=(
+            "The system trust store was scanned and every certificate "
+            "uses classical signature algorithms.  Trust-store rotation "
+            "to PQC roots will be required before pure-PQC chains "
+            "validate against this host."
+        ),
+        default_level="note",
+        help_uri=f"{SARIF_HELP_BASE}/pqc-004-classical-only-trust-store.md",
+    ),
+    RuleSpec(
+        id="pqc-005-slh-dsa-in-tls-context",
+        short_description=(
+            "SLH-DSA exposed for TLS use; signatures are large for handshakes."
+        ),
+        full_description=(
+            "OpenSSL is exposing SLH-DSA (SPHINCS+) signature "
+            "algorithms.  SLH-DSA signatures are an order of magnitude "
+            "larger than ML-DSA and substantially slow TLS handshakes; "
+            "ML-DSA is the recommended TLS signature primitive in NIST "
+            "PQC migration guidance."
+        ),
+        default_level="warning",
+        help_uri=f"{SARIF_HELP_BASE}/pqc-005-slh-dsa-in-tls-context.md",
+    ),
+    RuleSpec(
+        id="pqc-006-no-network-hsm-pqc-firmware",
+        short_description=(
+            "Network HSM client present but appliance is not PQC-capable."
+        ),
+        full_description=(
+            "A network-attached HSM client integration is installed "
+            "on the host, but the appliance has not been flagged as "
+            "PQC-capable.  Confirm the appliance firmware version "
+            "supports ML-KEM / ML-DSA before depending on the HSM "
+            "for PQC operations."
+        ),
+        default_level="warning",
+        help_uri=f"{SARIF_HELP_BASE}/pqc-006-no-network-hsm-pqc-firmware.md",
+    ),
+)
+
+
+def _sarif_host_properties(r: Report) -> dict[str, Any]:
+    """Run-level host-context property bag.
+
+    SARIF 2.1.0 lets us attach an arbitrary `properties` bag at the
+    `run` level so consumers (Splunk dashboards, custom scripts) can
+    correlate findings to a specific host without scraping `message`."""
+    return {
+        "host:hostname": r.hostname,
+        "host:os": r.os,
+        "host:arch": r.arch,
+        "tool:schema_version": r.schema_version,
+        "tool:version": SCRIPT_VERSION,
+        "report:generated_at": r.generated_at,
+    }
+
+
+def build_findings(r: Report) -> list[Finding]:
+    """Project a Report into typed Finding records.
+
+    Each rule is a small predicate over Report state.  Order is
+    deterministic — RULE_SPECS order is preserved so SARIF result
+    indexing is stable across runs on the same host."""
+    findings: list[Finding] = []
+
+    osinfo = r.openssl
+    if osinfo.get("available") and not osinfo.get("pqc_native", False):
+        findings.append(
+            Finding(
+                rule_id="pqc-001-openssl-pre-3.5",
+                level="warning",
+                message=(
+                    f"OpenSSL {osinfo.get('version', 'unknown')} is older "
+                    "than 3.5.0 — native ML-KEM / ML-DSA are not available."
+                ),
+                properties={
+                    "openssl:version": osinfo.get("version"),
+                    "openssl:upgrade_path": osinfo.get("upgrade_path"),
+                },
+            )
+        )
+
+    fc = r.fips_pqc_conflict
+    if fc.get("in_conflict"):
+        findings.append(
+            Finding(
+                rule_id="pqc-002-fips-pqc-conflict",
+                level="error",
+                message=str(
+                    fc.get("explanation") or "FIPS / PQC provider conflict."
+                ),
+                properties={
+                    "fips:kernel": r.fips.get("kernel"),
+                    "fips:openssl_provider": r.fips.get("openssl_provider"),
+                    "openssl:kem_algorithms": list(
+                        osinfo.get("kem_algorithms") or []
+                    ),
+                    "openssl:sig_algorithms": list(
+                        osinfo.get("sig_algorithms") or []
+                    ),
+                },
+            )
+        )
+
+    if r.replace_required:
+        findings.append(
+            Finding(
+                rule_id="pqc-003-no-pqc-isa-support",
+                level="warning",
+                message=(
+                    f"ISA tier '{r.isa_tier}' and no PQC-capable accelerator "
+                    "detected; software-only PQC is not viable on this host."
+                ),
+                properties={
+                    "isa:tier": r.isa_tier,
+                    "isa:score": r.isa_score,
+                    "isa:reason": r.isa_reason,
+                },
+            )
+        )
+
+    ts = r.trust_store
+    if (
+        ts.get("available")
+        and ts.get("total_certs", 0) > 0
+        and ts.get("pqc_certs", 0) == 0
+        and ts.get("hybrid_certs", 0) == 0
+    ):
+        findings.append(
+            Finding(
+                rule_id="pqc-004-classical-only-trust-store",
+                level="note",
+                message=(
+                    f"Scanned {ts.get('total_certs', 0)} certificates across "
+                    f"{len(ts.get('scanned_dirs') or [])} trust-store "
+                    "directories; every cert uses classical signatures."
+                ),
+                properties={
+                    "trust_store:total_certs": ts.get("total_certs"),
+                    "trust_store:pqc_certs": ts.get("pqc_certs"),
+                    "trust_store:hybrid_certs": ts.get("hybrid_certs"),
+                    "trust_store:scanned_dirs": list(
+                        ts.get("scanned_dirs") or []
+                    ),
+                },
+            )
+        )
+
+    sigs = list(osinfo.get("sig_algorithms") or [])
+    slh_dsa = sorted(
+        s for s in sigs if isinstance(s, str) and s.startswith("SLH-DSA")
+    )
+    if slh_dsa:
+        findings.append(
+            Finding(
+                rule_id="pqc-005-slh-dsa-in-tls-context",
+                level="warning",
+                message=(
+                    "OpenSSL exposes SLH-DSA signature algorithms "
+                    f"({', '.join(slh_dsa)}); prefer ML-DSA for TLS handshakes."
+                ),
+                properties={"openssl:slh_dsa_algorithms": slh_dsa},
+            )
+        )
+
+    network_hsms_no_pqc = [
+        a
+        for a in r.accelerators
+        if a.get("kind") == "network_hsm" and not a.get("pqc_capable")
+    ]
+    if network_hsms_no_pqc:
+        names = sorted(
+            {str(a.get("name") or "unknown") for a in network_hsms_no_pqc}
+        )
+        findings.append(
+            Finding(
+                rule_id="pqc-006-no-network-hsm-pqc-firmware",
+                level="warning",
+                message=(
+                    f"Network HSM client present ({', '.join(names)}) but "
+                    "the appliance is not flagged as PQC-capable.  Verify "
+                    "appliance firmware before relying on it for PQC."
+                ),
+                properties={"hsm:network_hsm_names": names},
+            )
+        )
+
+    return findings
+
+
+def _sarif_rule_descriptor(spec: RuleSpec) -> dict[str, Any]:
+    return {
+        "id": spec.id,
+        "name": spec.id,
+        "shortDescription": {"text": spec.short_description},
+        "fullDescription": {"text": spec.full_description},
+        "helpUri": spec.help_uri,
+        "defaultConfiguration": {"level": spec.default_level},
+    }
+
+
+def _sarif_result(finding: Finding, rule_index: int) -> dict[str, Any]:
+    return {
+        "ruleId": finding.rule_id,
+        "ruleIndex": rule_index,
+        "level": finding.level,
+        "message": {"text": finding.message},
+        "properties": finding.properties,
+    }
+
+
+def render_sarif(r: Report) -> str:
+    """Render the report as a SARIF 2.1.0 log document.
+
+    Every rule from RULE_SPECS is emitted in the run's tool-driver
+    descriptor — tooling can render rule metadata even when no result
+    references the rule.  Only matched rules become results."""
+    rules = [_sarif_rule_descriptor(s) for s in RULE_SPECS]
+    rule_index_by_id = {s.id: i for i, s in enumerate(RULE_SPECS)}
+    findings = build_findings(r)
+    results = [
+        _sarif_result(f, rule_index_by_id[f.rule_id])
+        for f in findings
+        if f.rule_id in rule_index_by_id
+    ]
+    log: dict[str, Any] = {
+        "$schema": SARIF_SCHEMA_URI,
+        "version": SARIF_VERSION,
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "pqc-readiness",
+                        "version": SCRIPT_VERSION,
+                        "informationUri": (
+                            "https://github.com/aclater/pqc-readiness"
+                        ),
+                        "rules": rules,
+                    }
+                },
+                "results": results,
+                "properties": _sarif_host_properties(r),
+            }
+        ],
+    }
+    return json.dumps(log, indent=2)
+
+
 def render_text(r: Report) -> str:
     L: list[str] = []
     bar = "=" * 76
@@ -4718,6 +5064,11 @@ def main() -> int:
         help="emit CycloneDX 1.6 CBOM JSON (NIST IR 8547)",
     )
     ap.add_argument(
+        "--sarif",
+        action="store_true",
+        help="emit SARIF 2.1.0 findings (OASIS) for security pipelines",
+    )
+    ap.add_argument(
         "--bench", action="store_true", help="run PQC + classical microbench"
     )
     ap.add_argument(
@@ -4822,6 +5173,7 @@ def main() -> int:
         and not args.json
         and not args.markdown
         and not args.cbom
+        and not args.sarif
     )
 
     arch = platform.machine().lower()
@@ -4972,6 +5324,8 @@ def main() -> int:
         print(json.dumps(asdict(r), indent=2))
     elif args.cbom:
         print(render_cbom(r))
+    elif args.sarif:
+        print(render_sarif(r))
     elif args.markdown:
         print(render_markdown(r))
     elif args.quiet:

--- a/tests/fixtures/sarif/sarif-2.1.0.schema.json
+++ b/tests/fixtures/sarif/sarif-2.1.0.schema.json
@@ -1,0 +1,2882 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "additionalProperties": false,
+  "definitions": {
+    "address": {
+      "description": "A physical or virtual address, or a range of addresses, in an 'addressable region' (memory or a binary file).",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "absoluteAddress": {
+          "description": "The address expressed as a byte offset from the start of the addressable region.",
+          "type": "integer",
+          "minimum": -1,
+          "default": -1
+        },
+        "relativeAddress": {
+          "description": "The address expressed as a byte offset from the absolute address of the top-most parent object.",
+          "type": "integer"
+        },
+        "length": {
+          "description": "The number of bytes in this range of addresses.",
+          "type": "integer"
+        },
+        "kind": {
+          "description": "An open-ended string that identifies the address kind. 'data', 'function', 'header','instruction', 'module', 'page', 'section', 'segment', 'stack', 'stackFrame', 'table' are well-known values.",
+          "type": "string"
+        },
+        "name": {
+          "description": "A name that is associated with the address, e.g., '.text'.",
+          "type": "string"
+        },
+        "fullyQualifiedName": {
+          "description": "A human-readable fully qualified name that is associated with the address.",
+          "type": "string"
+        },
+        "offsetFromParent": {
+          "description": "The byte offset of this address from the absolute or relative address of the parent object.",
+          "type": "integer"
+        },
+        "index": {
+          "description": "The index within run.addresses of the cached object for this address.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "parentIndex": {
+          "description": "The index within run.addresses of the parent object.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the address."
+        }
+      }
+    },
+    "artifact": {
+      "description": "A single artifact. In some cases, this artifact might be nested within another artifact.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "description": {
+          "$ref": "#/definitions/message",
+          "description": "A short description of the artifact."
+        },
+        "location": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "The location of the artifact."
+        },
+        "parentIndex": {
+          "description": "Identifies the index of the immediate parent of the artifact, if this artifact is nested.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "offset": {
+          "description": "The offset in bytes of the artifact within its containing artifact.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "length": {
+          "description": "The length of the artifact in bytes.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "roles": {
+          "description": "The role or roles played by the artifact in the analysis.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "enum": [
+              "analysisTarget",
+              "attachment",
+              "responseFile",
+              "resultFile",
+              "standardStream",
+              "tracedFile",
+              "unmodified",
+              "modified",
+              "added",
+              "deleted",
+              "renamed",
+              "uncontrolled",
+              "driver",
+              "extension",
+              "translation",
+              "taxonomy",
+              "policy",
+              "referencedOnCommandLine",
+              "memoryContents",
+              "directory",
+              "userSpecifiedConfiguration",
+              "toolSpecifiedConfiguration",
+              "debugOutputFile"
+            ]
+          }
+        },
+        "mimeType": {
+          "description": "The MIME type (RFC 2045) of the artifact.",
+          "type": "string",
+          "pattern": "[^/]+/.+"
+        },
+        "contents": {
+          "$ref": "#/definitions/artifactContent",
+          "description": "The contents of the artifact."
+        },
+        "encoding": {
+          "description": "Specifies the encoding for an artifact object that refers to a text file.",
+          "type": "string"
+        },
+        "sourceLanguage": {
+          "description": "Specifies the source language for any artifact object that refers to a text file that contains source code.",
+          "type": "string"
+        },
+        "hashes": {
+          "description": "A dictionary, each of whose keys is the name of a hash function and each of whose values is the hashed value of the artifact produced by the specified hash function.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "lastModifiedTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the artifact was most recently modified. See \"Date/time properties\" in the SARIF spec for the required format.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the artifact."
+        }
+      }
+    },
+    "artifactChange": {
+      "description": "A change to a single artifact.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "artifactLocation": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "The location of the artifact to change."
+        },
+        "replacements": {
+          "description": "An array of replacement objects, each of which represents the replacement of a single region in a single artifact specified by 'artifactLocation'.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": false,
+          "items": {
+            "$ref": "#/definitions/replacement"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the change."
+        }
+      },
+      "required": ["artifactLocation", "replacements"]
+    },
+    "artifactContent": {
+      "description": "Represents the contents of an artifact.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "text": {
+          "description": "UTF-8-encoded content from a text artifact.",
+          "type": "string"
+        },
+        "binary": {
+          "description": "MIME Base64-encoded content from a binary artifact, or from a text artifact in its original encoding.",
+          "type": "string"
+        },
+        "rendered": {
+          "$ref": "#/definitions/multiformatMessageString",
+          "description": "An alternate rendered representation of the artifact (e.g., a decompiled representation of a binary region)."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the artifact content."
+        }
+      }
+    },
+    "artifactLocation": {
+      "description": "Specifies the location of an artifact.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "uri": {
+          "description": "A string containing a valid relative or absolute URI.",
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "uriBaseId": {
+          "description": "A string which indirectly specifies the absolute URI with respect to which a relative URI in the \"uri\" property is interpreted.",
+          "type": "string"
+        },
+        "index": {
+          "description": "The index within the run artifacts array of the artifact object associated with the artifact location.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "description": {
+          "$ref": "#/definitions/message",
+          "description": "A short description of the artifact location."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the artifact location."
+        }
+      }
+    },
+    "attachment": {
+      "description": "An artifact relevant to a result.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "$ref": "#/definitions/message",
+          "description": "A message describing the role played by the attachment."
+        },
+        "artifactLocation": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "The location of the attachment."
+        },
+        "regions": {
+          "description": "An array of regions of interest within the attachment.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/region"
+          }
+        },
+        "rectangles": {
+          "description": "An array of rectangles specifying areas of interest within the image.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/rectangle"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the attachment."
+        }
+      },
+      "required": ["artifactLocation"]
+    },
+    "codeFlow": {
+      "description": "A set of threadFlows which together describe a pattern of code execution relevant to detecting a result.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "message": {
+          "$ref": "#/definitions/message",
+          "description": "A message relevant to the code flow."
+        },
+        "threadFlows": {
+          "description": "An array of one or more unique threadFlow objects, each of which describes the progress of a program through a thread of execution.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": false,
+          "items": {
+            "$ref": "#/definitions/threadFlow"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the code flow."
+        }
+      },
+      "required": ["threadFlows"]
+    },
+    "configurationOverride": {
+      "description": "Information about how a specific rule or notification was reconfigured at runtime.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "configuration": {
+          "$ref": "#/definitions/reportingConfiguration",
+          "description": "Specifies how the rule or notification was configured during the scan."
+        },
+        "descriptor": {
+          "$ref": "#/definitions/reportingDescriptorReference",
+          "description": "A reference used to locate the descriptor whose configuration was overridden."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the configuration override."
+        }
+      },
+      "required": ["configuration", "descriptor"]
+    },
+    "conversion": {
+      "description": "Describes how a converter transformed the output of a static analysis tool from the analysis tool's native output format into the SARIF format.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "tool": {
+          "$ref": "#/definitions/tool",
+          "description": "A tool object that describes the converter."
+        },
+        "invocation": {
+          "$ref": "#/definitions/invocation",
+          "description": "An invocation object that describes the invocation of the converter."
+        },
+        "analysisToolLogFiles": {
+          "description": "The locations of the analysis tool's per-run log files.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/artifactLocation"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the conversion."
+        }
+      },
+      "required": ["tool"]
+    },
+    "edge": {
+      "description": "Represents a directed edge in a graph.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "description": "A string that uniquely identifies the edge within its graph.",
+          "type": "string"
+        },
+        "label": {
+          "$ref": "#/definitions/message",
+          "description": "A short description of the edge."
+        },
+        "sourceNodeId": {
+          "description": "Identifies the source node (the node at which the edge starts).",
+          "type": "string"
+        },
+        "targetNodeId": {
+          "description": "Identifies the target node (the node at which the edge ends).",
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the edge."
+        }
+      },
+      "required": ["id", "sourceNodeId", "targetNodeId"]
+    },
+    "edgeTraversal": {
+      "description": "Represents the traversal of a single edge during a graph traversal.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "edgeId": {
+          "description": "Identifies the edge being traversed.",
+          "type": "string"
+        },
+        "message": {
+          "$ref": "#/definitions/message",
+          "description": "A message to display to the user as the edge is traversed."
+        },
+        "finalState": {
+          "description": "The values of relevant expressions after the edge has been traversed.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+        "stepOverEdgeCount": {
+          "description": "The number of edge traversals necessary to return from a nested graph.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the edge traversal."
+        }
+      },
+      "required": ["edgeId"]
+    },
+    "exception": {
+      "description": "Describes a runtime exception encountered during the execution of an analysis tool.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "type": "string",
+          "description": "A string that identifies the kind of exception, for example, the fully qualified type name of an object that was thrown, or the symbolic name of a signal."
+        },
+        "message": {
+          "description": "A message that describes the exception.",
+          "type": "string"
+        },
+        "stack": {
+          "$ref": "#/definitions/stack",
+          "description": "The sequence of function calls leading to the exception."
+        },
+        "innerExceptions": {
+          "description": "An array of exception objects each of which is considered a cause of this exception.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/exception"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the exception."
+        }
+      }
+    },
+    "externalProperties": {
+      "description": "The top-level element of an external property file.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "schema": {
+          "description": "The URI of the JSON schema corresponding to the version of the external property file format.",
+          "type": "string",
+          "format": "uri"
+        },
+        "version": {
+          "description": "The SARIF format version of this external properties object.",
+          "enum": ["2.1.0"]
+        },
+        "guid": {
+          "description": "A stable, unique identifier for this external properties object, in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "runGuid": {
+          "description": "A stable, unique identifier for the run associated with this external properties object, in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "conversion": {
+          "$ref": "#/definitions/conversion",
+          "description": "A conversion object that will be merged with a separate run."
+        },
+        "graphs": {
+          "description": "An array of graph objects that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "default": [],
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/graph"
+          }
+        },
+        "externalizedProperties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information that will be merged with a separate run."
+        },
+        "artifacts": {
+          "description": "An array of artifact objects that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/artifact"
+          }
+        },
+        "invocations": {
+          "description": "Describes the invocation of the analysis tool that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/invocation"
+          }
+        },
+        "logicalLocations": {
+          "description": "An array of logical locations such as namespaces, types or functions that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/logicalLocation"
+          }
+        },
+        "threadFlowLocations": {
+          "description": "An array of threadFlowLocation objects that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/threadFlowLocation"
+          }
+        },
+        "results": {
+          "description": "An array of result objects that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/result"
+          }
+        },
+        "taxonomies": {
+          "description": "Tool taxonomies that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+        "driver": {
+          "$ref": "#/definitions/toolComponent",
+          "description": "The analysis tool object that will be merged with a separate run."
+        },
+        "extensions": {
+          "description": "Tool extensions that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+        "policies": {
+          "description": "Tool policies that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+        "translations": {
+          "description": "Tool translations that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+        "addresses": {
+          "description": "Addresses that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/address"
+          }
+        },
+        "webRequests": {
+          "description": "Requests that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/webRequest"
+          }
+        },
+        "webResponses": {
+          "description": "Responses that will be merged with a separate run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/webResponse"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the external properties."
+        }
+      }
+    },
+    "externalPropertyFileReference": {
+      "description": "Contains information that enables a SARIF consumer to locate the external property file that contains the value of an externalized property associated with the run.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "location": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "The location of the external property file."
+        },
+        "guid": {
+          "description": "A stable, unique identifier for the external property file in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "itemCount": {
+          "description": "A non-negative integer specifying the number of items contained in the external property file.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the external property file."
+        }
+      },
+      "anyOf": [
+        {
+          "required": ["location"]
+        },
+        {
+          "required": ["guid"]
+        }
+      ]
+    },
+    "externalPropertyFileReferences": {
+      "description": "References to external property files that should be inlined with the content of a root log file.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "conversion": {
+          "$ref": "#/definitions/externalPropertyFileReference",
+          "description": "An external property file containing a run.conversion object to be merged with the root log file."
+        },
+        "graphs": {
+          "description": "An array of external property files containing a run.graphs object to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+        "externalizedProperties": {
+          "$ref": "#/definitions/externalPropertyFileReference",
+          "description": "An external property file containing a run.properties object to be merged with the root log file."
+        },
+        "artifacts": {
+          "description": "An array of external property files containing run.artifacts arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+        "invocations": {
+          "description": "An array of external property files containing run.invocations arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+        "logicalLocations": {
+          "description": "An array of external property files containing run.logicalLocations arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+        "threadFlowLocations": {
+          "description": "An array of external property files containing run.threadFlowLocations arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+        "results": {
+          "description": "An array of external property files containing run.results arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+        "taxonomies": {
+          "description": "An array of external property files containing run.taxonomies arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+        "addresses": {
+          "description": "An array of external property files containing run.addresses arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+        "driver": {
+          "$ref": "#/definitions/externalPropertyFileReference",
+          "description": "An external property file containing a run.driver object to be merged with the root log file."
+        },
+        "extensions": {
+          "description": "An array of external property files containing run.extensions arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+        "policies": {
+          "description": "An array of external property files containing run.policies arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+        "translations": {
+          "description": "An array of external property files containing run.translations arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+        "webRequests": {
+          "description": "An array of external property files containing run.requests arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+        "webResponses": {
+          "description": "An array of external property files containing run.responses arrays to be merged with the root log file.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/externalPropertyFileReference"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the external property files."
+        }
+      }
+    },
+    "fix": {
+      "description": "A proposed fix for the problem represented by a result object. A fix specifies a set of artifacts to modify. For each artifact, it specifies a set of bytes to remove, and provides a set of new bytes to replace them.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "description": {
+          "$ref": "#/definitions/message",
+          "description": "A message that describes the proposed fix, enabling viewers to present the proposed change to an end user."
+        },
+        "artifactChanges": {
+          "description": "One or more artifact changes that comprise a fix for a result.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/artifactChange"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the fix."
+        }
+      },
+      "required": ["artifactChanges"]
+    },
+    "graph": {
+      "description": "A network of nodes and directed edges that describes some aspect of the structure of the code (for example, a call graph).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "$ref": "#/definitions/message",
+          "description": "A description of the graph."
+        },
+        "nodes": {
+          "description": "An array of node objects representing the nodes of the graph.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/node"
+          }
+        },
+        "edges": {
+          "description": "An array of edge objects representing the edges of the graph.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/edge"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the graph."
+        }
+      }
+    },
+    "graphTraversal": {
+      "description": "Represents a path through a graph.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "runGraphIndex": {
+          "description": "The index within the run.graphs to be associated with the result.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "resultGraphIndex": {
+          "description": "The index within the result.graphs to be associated with the result.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "description": {
+          "$ref": "#/definitions/message",
+          "description": "A description of this graph traversal."
+        },
+        "initialState": {
+          "description": "Values of relevant expressions at the start of the graph traversal that may change during graph traversal.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+        "immutableState": {
+          "description": "Values of relevant expressions at the start of the graph traversal that remain constant for the graph traversal.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+        "edgeTraversals": {
+          "description": "The sequences of edges traversed by this graph traversal.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/edgeTraversal"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the graph traversal."
+        }
+      },
+      "oneOf": [
+        {
+          "required": ["runGraphIndex"]
+        },
+        {
+          "required": ["resultGraphIndex"]
+        }
+      ]
+    },
+    "invocation": {
+      "description": "The runtime environment of the analysis tool run.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "commandLine": {
+          "description": "The command line used to invoke the tool.",
+          "type": "string"
+        },
+        "arguments": {
+          "description": "An array of strings, containing in order the command line arguments passed to the tool from the operating system.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "items": {
+            "type": "string"
+          }
+        },
+        "responseFiles": {
+          "description": "The locations of any response files specified on the tool's command line.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/artifactLocation"
+          }
+        },
+        "startTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the invocation started. See \"Date/time properties\" in the SARIF spec for the required format.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "endTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the invocation ended. See \"Date/time properties\" in the SARIF spec for the required format.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "exitCode": {
+          "description": "The process exit code.",
+          "type": "integer"
+        },
+        "ruleConfigurationOverrides": {
+          "description": "An array of configurationOverride objects that describe rules related runtime overrides.",
+          "type": "array",
+          "minItems": 0,
+          "default": [],
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/configurationOverride"
+          }
+        },
+        "notificationConfigurationOverrides": {
+          "description": "An array of configurationOverride objects that describe notifications related runtime overrides.",
+          "type": "array",
+          "minItems": 0,
+          "default": [],
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/configurationOverride"
+          }
+        },
+        "toolExecutionNotifications": {
+          "description": "A list of runtime conditions detected by the tool during the analysis.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/notification"
+          }
+        },
+        "toolConfigurationNotifications": {
+          "description": "A list of conditions detected by the tool that are relevant to the tool's configuration.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/notification"
+          }
+        },
+        "exitCodeDescription": {
+          "description": "The reason for the process exit.",
+          "type": "string"
+        },
+        "exitSignalName": {
+          "description": "The name of the signal that caused the process to exit.",
+          "type": "string"
+        },
+        "exitSignalNumber": {
+          "description": "The numeric value of the signal that caused the process to exit.",
+          "type": "integer"
+        },
+        "processStartFailureMessage": {
+          "description": "The reason given by the operating system that the process failed to start.",
+          "type": "string"
+        },
+        "executionSuccessful": {
+          "description": "Specifies whether the tool's execution completed successfully.",
+          "type": "boolean"
+        },
+        "machine": {
+          "description": "The machine on which the invocation occurred.",
+          "type": "string"
+        },
+        "account": {
+          "description": "The account under which the invocation occurred.",
+          "type": "string"
+        },
+        "processId": {
+          "description": "The id of the process in which the invocation occurred.",
+          "type": "integer"
+        },
+        "executableLocation": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "An absolute URI specifying the location of the executable that was invoked."
+        },
+        "workingDirectory": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "The working directory for the invocation."
+        },
+        "environmentVariables": {
+          "description": "The environment variables associated with the analysis tool process, expressed as key/value pairs.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "stdin": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "A file containing the standard input stream to the process that was invoked."
+        },
+        "stdout": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "A file containing the standard output stream from the process that was invoked."
+        },
+        "stderr": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "A file containing the standard error stream from the process that was invoked."
+        },
+        "stdoutStderr": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "A file containing the interleaved standard output and standard error stream from the process that was invoked."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the invocation."
+        }
+      },
+      "required": ["executionSuccessful"]
+    },
+    "location": {
+      "description": "A location within a programming artifact.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Value that distinguishes this location from all other locations within a single result object.",
+          "type": "integer",
+          "minimum": -1,
+          "default": -1
+        },
+        "physicalLocation": {
+          "$ref": "#/definitions/physicalLocation",
+          "description": "Identifies the artifact and region."
+        },
+        "logicalLocations": {
+          "description": "The logical locations associated with the result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/logicalLocation"
+          }
+        },
+        "message": {
+          "$ref": "#/definitions/message",
+          "description": "A message relevant to the location."
+        },
+        "annotations": {
+          "description": "A set of regions relevant to the location.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/region"
+          }
+        },
+        "relationships": {
+          "description": "An array of objects that describe relationships between this location and others.",
+          "type": "array",
+          "default": [],
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/locationRelationship"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the location."
+        }
+      }
+    },
+    "locationRelationship": {
+      "description": "Information about the relation of one location to another.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "target": {
+          "description": "A reference to the related location.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "kinds": {
+          "description": "A set of distinct strings that categorize the relationship. Well-known kinds include 'includes', 'isIncludedBy' and 'relevant'.",
+          "type": "array",
+          "default": ["relevant"],
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "description": {
+          "$ref": "#/definitions/message",
+          "description": "A description of the location relationship."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the location relationship."
+        }
+      },
+      "required": ["target"]
+    },
+    "logicalLocation": {
+      "description": "A logical location of a construct that produced a result.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Identifies the construct in which the result occurred. For example, this property might contain the name of a class or a method.",
+          "type": "string"
+        },
+        "index": {
+          "description": "The index within the logical locations array.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "fullyQualifiedName": {
+          "description": "The human-readable fully qualified name of the logical location.",
+          "type": "string"
+        },
+        "decoratedName": {
+          "description": "The machine-readable name for the logical location, such as a mangled function name provided by a C++ compiler that encodes calling convention, return type and other details along with the function name.",
+          "type": "string"
+        },
+        "parentIndex": {
+          "description": "Identifies the index of the immediate parent of the construct in which the result was detected. For example, this property might point to a logical location that represents the namespace that holds a type.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "kind": {
+          "description": "The type of construct this logical location component refers to. Should be one of 'function', 'member', 'module', 'namespace', 'parameter', 'resource', 'returnType', 'type', 'variable', 'object', 'array', 'property', 'value', 'element', 'text', 'attribute', 'comment', 'declaration', 'dtd' or 'processingInstruction', if any of those accurately describe the construct.",
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the logical location."
+        }
+      }
+    },
+    "message": {
+      "description": "Encapsulates a message intended to be read by the end user.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "text": {
+          "description": "A plain text message string.",
+          "type": "string"
+        },
+        "markdown": {
+          "description": "A Markdown message string.",
+          "type": "string"
+        },
+        "id": {
+          "description": "The identifier for this message.",
+          "type": "string"
+        },
+        "arguments": {
+          "description": "An array of strings to substitute into the message string.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the message."
+        }
+      },
+      "anyOf": [
+        {
+          "required": ["text"]
+        },
+        {
+          "required": ["id"]
+        }
+      ]
+    },
+    "multiformatMessageString": {
+      "description": "A message string or message format string rendered in multiple formats.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "text": {
+          "description": "A plain text message string or format string.",
+          "type": "string"
+        },
+        "markdown": {
+          "description": "A Markdown message string or format string.",
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the message."
+        }
+      },
+      "required": ["text"]
+    },
+    "node": {
+      "description": "Represents a node in a graph.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "description": "A string that uniquely identifies the node within its graph.",
+          "type": "string"
+        },
+        "label": {
+          "$ref": "#/definitions/message",
+          "description": "A short description of the node."
+        },
+        "location": {
+          "$ref": "#/definitions/location",
+          "description": "A code location associated with the node."
+        },
+        "children": {
+          "description": "Array of child nodes.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/node"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the node."
+        }
+      },
+      "required": ["id"]
+    },
+    "notification": {
+      "description": "Describes a condition relevant to the tool itself, as opposed to being relevant to a target being analyzed by the tool.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "locations": {
+          "description": "The locations relevant to this notification.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/location"
+          }
+        },
+        "message": {
+          "$ref": "#/definitions/message",
+          "description": "A message that describes the condition that was encountered."
+        },
+        "level": {
+          "description": "A value specifying the severity level of the notification.",
+          "default": "warning",
+          "enum": ["none", "note", "warning", "error"]
+        },
+        "threadId": {
+          "description": "The thread identifier of the code that generated the notification.",
+          "type": "integer"
+        },
+        "timeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the analysis tool generated the notification.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "exception": {
+          "$ref": "#/definitions/exception",
+          "description": "The runtime exception, if any, relevant to this notification."
+        },
+        "descriptor": {
+          "$ref": "#/definitions/reportingDescriptorReference",
+          "description": "A reference used to locate the descriptor relevant to this notification."
+        },
+        "associatedRule": {
+          "$ref": "#/definitions/reportingDescriptorReference",
+          "description": "A reference used to locate the rule descriptor associated with this notification."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the notification."
+        }
+      },
+      "required": ["message"]
+    },
+    "physicalLocation": {
+      "description": "A physical location relevant to a result. Specifies a reference to a programming artifact together with a range of bytes or characters within that artifact.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/address",
+          "description": "The address of the location."
+        },
+        "artifactLocation": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "The location of the artifact."
+        },
+        "region": {
+          "$ref": "#/definitions/region",
+          "description": "Specifies a portion of the artifact."
+        },
+        "contextRegion": {
+          "$ref": "#/definitions/region",
+          "description": "Specifies a portion of the artifact that encloses the region. Allows a viewer to display additional context around the region."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the physical location."
+        }
+      },
+      "anyOf": [
+        {
+          "required": ["address"]
+        },
+        {
+          "required": ["artifactLocation"]
+        }
+      ]
+    },
+    "propertyBag": {
+      "description": "Key/value pairs that provide additional information about the object.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "tags": {
+          "description": "A set of distinct strings that provide additional information.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "rectangle": {
+      "description": "An area within an image.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "top": {
+          "description": "The Y coordinate of the top edge of the rectangle, measured in the image's natural units.",
+          "type": "number"
+        },
+        "left": {
+          "description": "The X coordinate of the left edge of the rectangle, measured in the image's natural units.",
+          "type": "number"
+        },
+        "bottom": {
+          "description": "The Y coordinate of the bottom edge of the rectangle, measured in the image's natural units.",
+          "type": "number"
+        },
+        "right": {
+          "description": "The X coordinate of the right edge of the rectangle, measured in the image's natural units.",
+          "type": "number"
+        },
+        "message": {
+          "$ref": "#/definitions/message",
+          "description": "A message relevant to the rectangle."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the rectangle."
+        }
+      }
+    },
+    "region": {
+      "description": "A region within an artifact where a result was detected.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "startLine": {
+          "description": "The line number of the first character in the region.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "startColumn": {
+          "description": "The column number of the first character in the region.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "endLine": {
+          "description": "The line number of the last character in the region.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "endColumn": {
+          "description": "The column number of the character following the end of the region.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "charOffset": {
+          "description": "The zero-based offset from the beginning of the artifact of the first character in the region.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "charLength": {
+          "description": "The length of the region in characters.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "byteOffset": {
+          "description": "The zero-based offset from the beginning of the artifact of the first byte in the region.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "byteLength": {
+          "description": "The length of the region in bytes.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "snippet": {
+          "$ref": "#/definitions/artifactContent",
+          "description": "The portion of the artifact contents within the specified region."
+        },
+        "message": {
+          "$ref": "#/definitions/message",
+          "description": "A message relevant to the region."
+        },
+        "sourceLanguage": {
+          "description": "Specifies the source language, if any, of the portion of the artifact specified by the region object.",
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the region."
+        }
+      }
+    },
+    "replacement": {
+      "description": "The replacement of a single region of an artifact.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "deletedRegion": {
+          "$ref": "#/definitions/region",
+          "description": "The region of the artifact to delete."
+        },
+        "insertedContent": {
+          "$ref": "#/definitions/artifactContent",
+          "description": "The content to insert at the location specified by the 'deletedRegion' property."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the replacement."
+        }
+      },
+      "required": ["deletedRegion"]
+    },
+    "reportingDescriptor": {
+      "description": "Metadata that describes a specific report produced by the tool, as part of the analysis it provides or its runtime reporting.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "A stable, opaque identifier for the report.",
+          "type": "string"
+        },
+        "deprecatedIds": {
+          "description": "An array of stable, opaque identifiers by which this report was known in some previous version of the analysis tool.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "guid": {
+          "description": "A unique identifier for the reporting descriptor in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "deprecatedGuids": {
+          "description": "An array of unique identifies in the form of a GUID by which this report was known in some previous version of the analysis tool.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+          }
+        },
+        "name": {
+          "description": "A report identifier that is understandable to an end user.",
+          "type": "string"
+        },
+        "deprecatedNames": {
+          "description": "An array of readable identifiers by which this report was known in some previous version of the analysis tool.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "shortDescription": {
+          "$ref": "#/definitions/multiformatMessageString",
+          "description": "A concise description of the report. Should be a single sentence that is understandable when visible space is limited to a single line of text."
+        },
+        "fullDescription": {
+          "$ref": "#/definitions/multiformatMessageString",
+          "description": "A description of the report. Should, as far as possible, provide details sufficient to enable resolution of any problem indicated by the result."
+        },
+        "messageStrings": {
+          "description": "A set of name/value pairs with arbitrary names. Each value is a multiformatMessageString object, which holds message strings in plain text and (optionally) Markdown format. The strings can include placeholders, which can be used to construct a message in combination with an arbitrary number of additional string arguments.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+        "defaultConfiguration": {
+          "$ref": "#/definitions/reportingConfiguration",
+          "description": "Default reporting configuration information."
+        },
+        "helpUri": {
+          "description": "A URI where the primary documentation for the report can be found.",
+          "type": "string",
+          "format": "uri"
+        },
+        "help": {
+          "$ref": "#/definitions/multiformatMessageString",
+          "description": "Provides the primary documentation for the report, useful when there is no online documentation."
+        },
+        "relationships": {
+          "description": "An array of objects that describe relationships between this reporting descriptor and others.",
+          "type": "array",
+          "default": [],
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/reportingDescriptorRelationship"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the report."
+        }
+      },
+      "required": ["id"]
+    },
+    "reportingConfiguration": {
+      "description": "Information about a rule or notification that can be configured at runtime.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "description": "Specifies whether the report may be produced during the scan.",
+          "type": "boolean",
+          "default": true
+        },
+        "level": {
+          "description": "Specifies the failure level for the report.",
+          "default": "warning",
+          "enum": ["none", "note", "warning", "error"]
+        },
+        "rank": {
+          "description": "Specifies the relative priority of the report. Used for analysis output only.",
+          "type": "number",
+          "default": -1,
+          "minimum": -1,
+          "maximum": 100
+        },
+        "parameters": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Contains configuration information specific to a report."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the reporting configuration."
+        }
+      }
+    },
+    "reportingDescriptorReference": {
+      "description": "Information about how to locate a relevant reporting descriptor.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "description": "The id of the descriptor.",
+          "type": "string"
+        },
+        "index": {
+          "description": "The index into an array of descriptors in toolComponent.ruleDescriptors, toolComponent.notificationDescriptors, or toolComponent.taxonomyDescriptors, depending on context.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "guid": {
+          "description": "A guid that uniquely identifies the descriptor.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "toolComponent": {
+          "$ref": "#/definitions/toolComponentReference",
+          "description": "A reference used to locate the toolComponent associated with the descriptor."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the reporting descriptor reference."
+        }
+      },
+      "anyOf": [
+        {
+          "required": ["index"]
+        },
+        {
+          "required": ["guid"]
+        },
+        {
+          "required": ["id"]
+        }
+      ]
+    },
+    "reportingDescriptorRelationship": {
+      "description": "Information about the relation of one reporting descriptor to another.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "target": {
+          "$ref": "#/definitions/reportingDescriptorReference",
+          "description": "A reference to the related reporting descriptor."
+        },
+        "kinds": {
+          "description": "A set of distinct strings that categorize the relationship. Well-known kinds include 'canPrecede', 'canFollow', 'willPrecede', 'willFollow', 'superset', 'subset', 'equal', 'disjoint', 'relevant', and 'incomparable'.",
+          "type": "array",
+          "default": ["relevant"],
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "description": {
+          "$ref": "#/definitions/message",
+          "description": "A description of the reporting descriptor relationship."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the reporting descriptor reference."
+        }
+      },
+      "required": ["target"]
+    },
+    "result": {
+      "description": "A result produced by an analysis tool.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "ruleId": {
+          "description": "The stable, unique identifier of the rule, if any, to which this result is relevant.",
+          "type": "string"
+        },
+        "ruleIndex": {
+          "description": "The index within the tool component rules array of the rule object associated with this result.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "rule": {
+          "$ref": "#/definitions/reportingDescriptorReference",
+          "description": "A reference used to locate the rule descriptor relevant to this result."
+        },
+        "kind": {
+          "description": "A value that categorizes results by evaluation state.",
+          "default": "fail",
+          "enum": [
+            "notApplicable",
+            "pass",
+            "fail",
+            "review",
+            "open",
+            "informational"
+          ]
+        },
+        "level": {
+          "description": "A value specifying the severity level of the result.",
+          "default": "warning",
+          "enum": ["none", "note", "warning", "error"]
+        },
+        "message": {
+          "$ref": "#/definitions/message",
+          "description": "A message that describes the result. The first sentence of the message only will be displayed when visible space is limited."
+        },
+        "analysisTarget": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "Identifies the artifact that the analysis tool was instructed to scan. This need not be the same as the artifact where the result actually occurred."
+        },
+        "locations": {
+          "description": "The set of locations where the result was detected. Specify only one location unless the problem indicated by the result can only be corrected by making a change at every specified location.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/location"
+          }
+        },
+        "guid": {
+          "description": "A stable, unique identifier for the result in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "correlationGuid": {
+          "description": "A stable, unique identifier for the equivalence class of logically identical results to which this result belongs, in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "occurrenceCount": {
+          "description": "A positive integer specifying the number of times this logically unique result was observed in this run.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "partialFingerprints": {
+          "description": "A set of strings that contribute to the stable, unique identity of the result.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "fingerprints": {
+          "description": "A set of strings each of which individually defines a stable, unique identity for the result.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "stacks": {
+          "description": "An array of 'stack' objects relevant to the result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/stack"
+          }
+        },
+        "codeFlows": {
+          "description": "An array of 'codeFlow' objects relevant to the result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/codeFlow"
+          }
+        },
+        "graphs": {
+          "description": "An array of zero or more unique graph objects associated with the result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/graph"
+          }
+        },
+        "graphTraversals": {
+          "description": "An array of one or more unique 'graphTraversal' objects.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/graphTraversal"
+          }
+        },
+        "relatedLocations": {
+          "description": "A set of locations relevant to this result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/location"
+          }
+        },
+        "suppressions": {
+          "description": "A set of suppressions relevant to this result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/suppression"
+          }
+        },
+        "baselineState": {
+          "description": "The state of a result relative to a baseline of a previous run.",
+          "enum": ["new", "unchanged", "updated", "absent"]
+        },
+        "rank": {
+          "description": "A number representing the priority or importance of the result.",
+          "type": "number",
+          "default": -1,
+          "minimum": -1,
+          "maximum": 100
+        },
+        "attachments": {
+          "description": "A set of artifacts relevant to the result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/attachment"
+          }
+        },
+        "hostedViewerUri": {
+          "description": "An absolute URI at which the result can be viewed.",
+          "type": "string",
+          "format": "uri"
+        },
+        "workItemUris": {
+          "description": "The URIs of the work items associated with this result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "provenance": {
+          "$ref": "#/definitions/resultProvenance",
+          "description": "Information about how and when the result was detected."
+        },
+        "fixes": {
+          "description": "An array of 'fix' objects, each of which represents a proposed fix to the problem indicated by the result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/fix"
+          }
+        },
+        "taxa": {
+          "description": "An array of references to taxonomy reporting descriptors that are applicable to the result.",
+          "type": "array",
+          "default": [],
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/reportingDescriptorReference"
+          }
+        },
+        "webRequest": {
+          "$ref": "#/definitions/webRequest",
+          "description": "A web request associated with this result."
+        },
+        "webResponse": {
+          "$ref": "#/definitions/webResponse",
+          "description": "A web response associated with this result."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the result."
+        }
+      },
+      "required": ["message"]
+    },
+    "resultProvenance": {
+      "description": "Contains information about how and when a result was detected.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "firstDetectionTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the result was first detected. See \"Date/time properties\" in the SARIF spec for the required format.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "lastDetectionTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which the result was most recently detected. See \"Date/time properties\" in the SARIF spec for the required format.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "firstDetectionRunGuid": {
+          "description": "A GUID-valued string equal to the automationDetails.guid property of the run in which the result was first detected.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "lastDetectionRunGuid": {
+          "description": "A GUID-valued string equal to the automationDetails.guid property of the run in which the result was most recently detected.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "invocationIndex": {
+          "description": "The index within the run.invocations array of the invocation object which describes the tool invocation that detected the result.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "conversionSources": {
+          "description": "An array of physicalLocation objects which specify the portions of an analysis tool's output that a converter transformed into the result.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/physicalLocation"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the result."
+        }
+      }
+    },
+    "run": {
+      "description": "Describes a single run of an analysis tool, and contains the reported output of that run.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "tool": {
+          "$ref": "#/definitions/tool",
+          "description": "Information about the tool or tool pipeline that generated the results in this run. A run can only contain results produced by a single tool or tool pipeline. A run can aggregate results from multiple log files, as long as context around the tool run (tool command-line arguments and the like) is identical for all aggregated files."
+        },
+        "invocations": {
+          "description": "Describes the invocation of the analysis tool.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/invocation"
+          }
+        },
+        "conversion": {
+          "$ref": "#/definitions/conversion",
+          "description": "A conversion object that describes how a converter transformed an analysis tool's native reporting format into the SARIF format."
+        },
+        "language": {
+          "description": "The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter lowercase culture code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code associated with a country or region). The casing is recommended but not required (in order for this data to conform to RFC5646).",
+          "type": "string",
+          "default": "en-US",
+          "pattern": "^[a-zA-Z]{2}|^[a-zA-Z]{2}-[a-zA-Z]{2}?$"
+        },
+        "versionControlProvenance": {
+          "description": "Specifies the revision in version control of the artifacts that were scanned.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/versionControlDetails"
+          }
+        },
+        "originalUriBaseIds": {
+          "description": "The artifact location specified by each uriBaseId symbol on the machine where the tool originally ran.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/artifactLocation"
+          }
+        },
+        "artifacts": {
+          "description": "An array of artifact objects relevant to the run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/artifact"
+          }
+        },
+        "logicalLocations": {
+          "description": "An array of logical locations such as namespaces, types or functions.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/logicalLocation"
+          }
+        },
+        "graphs": {
+          "description": "An array of zero or more unique graph objects associated with the run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/graph"
+          }
+        },
+        "results": {
+          "description": "The set of results contained in an SARIF log. The results array can be omitted when a run is solely exporting rules metadata. It must be present (but may be empty) if a log file represents an actual scan.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "items": {
+            "$ref": "#/definitions/result"
+          }
+        },
+        "automationDetails": {
+          "$ref": "#/definitions/runAutomationDetails",
+          "description": "Automation details that describe this run."
+        },
+        "runAggregates": {
+          "description": "Automation details that describe the aggregate of runs to which this run belongs.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/runAutomationDetails"
+          }
+        },
+        "baselineGuid": {
+          "description": "The 'guid' property of a previous SARIF 'run' that comprises the baseline that was used to compute result 'baselineState' properties for the run.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "redactionTokens": {
+          "description": "An array of strings used to replace sensitive information in a redaction-aware property.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        },
+        "defaultEncoding": {
+          "description": "Specifies the default encoding for any artifact object that refers to a text file.",
+          "type": "string"
+        },
+        "defaultSourceLanguage": {
+          "description": "Specifies the default source language for any artifact object that refers to a text file that contains source code.",
+          "type": "string"
+        },
+        "newlineSequences": {
+          "description": "An ordered list of character sequences that were treated as line breaks when computing region information for the run.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "default": ["\r\n", "\n"],
+          "items": {
+            "type": "string"
+          }
+        },
+        "columnKind": {
+          "description": "Specifies the unit in which the tool measures columns.",
+          "enum": ["utf16CodeUnits", "unicodeCodePoints"]
+        },
+        "externalPropertyFileReferences": {
+          "$ref": "#/definitions/externalPropertyFileReferences",
+          "description": "References to external property files that should be inlined with the content of a root log file."
+        },
+        "threadFlowLocations": {
+          "description": "An array of threadFlowLocation objects cached at run level.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/threadFlowLocation"
+          }
+        },
+        "taxonomies": {
+          "description": "An array of toolComponent objects relevant to a taxonomy in which results are categorized.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+        "addresses": {
+          "description": "Addresses associated with this run instance, if any.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/address"
+          }
+        },
+        "translations": {
+          "description": "The set of available translations of the localized data provided by the tool.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+        "policies": {
+          "description": "Contains configurations that may potentially override both reportingDescriptor.defaultConfiguration (the tool's default severities) and invocation.configurationOverrides (severities established at run-time from the command line).",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+        "webRequests": {
+          "description": "An array of request objects cached at run level.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/webRequest"
+          }
+        },
+        "webResponses": {
+          "description": "An array of response objects cached at run level.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/webResponse"
+          }
+        },
+        "specialLocations": {
+          "$ref": "#/definitions/specialLocations",
+          "description": "A specialLocations object that defines locations of special significance to SARIF consumers."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the run."
+        }
+      },
+      "required": ["tool"]
+    },
+    "runAutomationDetails": {
+      "description": "Information that describes a run's identity and role within an engineering system process.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "description": {
+          "$ref": "#/definitions/message",
+          "description": "A description of the identity and role played within the engineering system by this object's containing run object."
+        },
+        "id": {
+          "description": "A hierarchical string that uniquely identifies this object's containing run object.",
+          "type": "string"
+        },
+        "guid": {
+          "description": "A stable, unique identifier for this object's containing run object in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "correlationGuid": {
+          "description": "A stable, unique identifier for the equivalence class of runs to which this object's containing run object belongs in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the run automation details."
+        }
+      }
+    },
+    "specialLocations": {
+      "description": "Defines locations of special significance to SARIF consumers.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "displayBase": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "Provides a suggestion to SARIF consumers to display file paths relative to the specified location."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the special locations."
+        }
+      }
+    },
+    "stack": {
+      "description": "A call stack that is relevant to a result.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "message": {
+          "$ref": "#/definitions/message",
+          "description": "A message relevant to this call stack."
+        },
+        "frames": {
+          "description": "An array of stack frames that represents a sequence of calls, rendered in reverse chronological order, that comprise the call stack.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "items": {
+            "$ref": "#/definitions/stackFrame"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the stack."
+        }
+      },
+      "required": ["frames"]
+    },
+    "stackFrame": {
+      "description": "A function call within a stack trace.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "location": {
+          "$ref": "#/definitions/location",
+          "description": "The location to which this stack frame refers."
+        },
+        "module": {
+          "description": "The name of the module that contains the code of this stack frame.",
+          "type": "string"
+        },
+        "threadId": {
+          "description": "The thread identifier of the stack frame.",
+          "type": "integer"
+        },
+        "parameters": {
+          "description": "The parameters of the call that is executing.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": false,
+          "default": [],
+          "items": {
+            "type": "string",
+            "default": []
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the stack frame."
+        }
+      }
+    },
+    "suppression": {
+      "description": "A suppression that is relevant to a result.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "guid": {
+          "description": "A stable, unique identifier for the suppression in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "kind": {
+          "description": "A string that indicates where the suppression is persisted.",
+          "enum": ["inSource", "external"]
+        },
+        "status": {
+          "description": "A string that indicates the review status of the suppression.",
+          "enum": ["accepted", "underReview", "rejected"]
+        },
+        "justification": {
+          "description": "A string representing the justification for the suppression.",
+          "type": "string"
+        },
+        "location": {
+          "$ref": "#/definitions/location",
+          "description": "Identifies the location associated with the suppression."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the suppression."
+        }
+      },
+      "required": ["kind"]
+    },
+    "threadFlow": {
+      "description": "Describes a sequence of code locations that specify a path through a single thread of execution such as an operating system or fiber.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "description": "An string that uniquely identifies the threadFlow within the codeFlow in which it occurs.",
+          "type": "string"
+        },
+        "message": {
+          "$ref": "#/definitions/message",
+          "description": "A message relevant to the thread flow."
+        },
+        "initialState": {
+          "description": "Values of relevant expressions at the start of the thread flow that may change during thread flow execution.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+        "immutableState": {
+          "description": "Values of relevant expressions at the start of the thread flow that remain constant.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+        "locations": {
+          "description": "A temporally ordered array of 'threadFlowLocation' objects, each of which describes a location visited by the tool while producing the result.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": false,
+          "items": {
+            "$ref": "#/definitions/threadFlowLocation"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the thread flow."
+        }
+      },
+      "required": ["locations"]
+    },
+    "threadFlowLocation": {
+      "description": "A location visited by an analysis tool while simulating or monitoring the execution of a program.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "index": {
+          "description": "The index within the run threadFlowLocations array.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "location": {
+          "$ref": "#/definitions/location",
+          "description": "The code location."
+        },
+        "stack": {
+          "$ref": "#/definitions/stack",
+          "description": "The call stack leading to this location."
+        },
+        "kinds": {
+          "description": "A set of distinct strings that categorize the thread flow location. Well-known kinds include 'acquire', 'release', 'enter', 'exit', 'call', 'return', 'branch', 'implicit', 'false', 'true', 'caution', 'danger', 'unknown', 'unreachable', 'taint', 'function', 'handler', 'lock', 'memory', 'resource', 'scope' and 'value'.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        },
+        "taxa": {
+          "description": "An array of references to rule or taxonomy reporting descriptors that are applicable to the thread flow location.",
+          "type": "array",
+          "default": [],
+          "minItems": 0,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/definitions/reportingDescriptorReference"
+          }
+        },
+        "module": {
+          "description": "The name of the module that contains the code that is executing.",
+          "type": "string"
+        },
+        "state": {
+          "description": "A dictionary, each of whose keys specifies a variable or expression, the associated value of which represents the variable or expression value. For an annotation of kind 'continuation', for example, this dictionary might hold the current assumed values of a set of global variables.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+        "nestingLevel": {
+          "description": "An integer representing a containment hierarchy within the thread flow.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "executionOrder": {
+          "description": "An integer representing the temporal order in which execution reached this location.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "executionTimeUtc": {
+          "description": "The Coordinated Universal Time (UTC) date and time at which this location was executed.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "importance": {
+          "description": "Specifies the importance of this location in understanding the code flow in which it occurs. The order from most to least important is \"essential\", \"important\", \"unimportant\". Default: \"important\".",
+          "enum": ["important", "essential", "unimportant"],
+          "default": "important"
+        },
+        "webRequest": {
+          "$ref": "#/definitions/webRequest",
+          "description": "A web request associated with this thread flow location."
+        },
+        "webResponse": {
+          "$ref": "#/definitions/webResponse",
+          "description": "A web response associated with this thread flow location."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the threadflow location."
+        }
+      }
+    },
+    "tool": {
+      "description": "The analysis tool that was run.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "driver": {
+          "$ref": "#/definitions/toolComponent",
+          "description": "The analysis tool that was run."
+        },
+        "extensions": {
+          "description": "Tool extensions that contributed to or reconfigured the analysis tool that was run.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponent"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the tool."
+        }
+      },
+      "required": ["driver"]
+    },
+    "toolComponent": {
+      "description": "A component, such as a plug-in or the driver, of the analysis tool that was run.",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "guid": {
+          "description": "A unique identifier for the tool component in the form of a GUID.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "name": {
+          "description": "The name of the tool component.",
+          "type": "string"
+        },
+        "organization": {
+          "description": "The organization or company that produced the tool component.",
+          "type": "string"
+        },
+        "product": {
+          "description": "A product suite to which the tool component belongs.",
+          "type": "string"
+        },
+        "productSuite": {
+          "description": "A localizable string containing the name of the suite of products to which the tool component belongs.",
+          "type": "string"
+        },
+        "shortDescription": {
+          "$ref": "#/definitions/multiformatMessageString",
+          "description": "A brief description of the tool component."
+        },
+        "fullDescription": {
+          "$ref": "#/definitions/multiformatMessageString",
+          "description": "A comprehensive description of the tool component."
+        },
+        "fullName": {
+          "description": "The name of the tool component along with its version and any other useful identifying information, such as its locale.",
+          "type": "string"
+        },
+        "version": {
+          "description": "The tool component version, in whatever format the component natively provides.",
+          "type": "string"
+        },
+        "semanticVersion": {
+          "description": "The tool component version in the format specified by Semantic Versioning 2.0.",
+          "type": "string"
+        },
+        "dottedQuadFileVersion": {
+          "description": "The binary version of the tool component's primary executable file expressed as four non-negative integers separated by a period (for operating systems that express file versions in this way).",
+          "type": "string",
+          "pattern": "[0-9]+(\\.[0-9]+){3}"
+        },
+        "releaseDateUtc": {
+          "description": "A string specifying the UTC date (and optionally, the time) of the component's release.",
+          "type": "string"
+        },
+        "downloadUri": {
+          "description": "The absolute URI from which the tool component can be downloaded.",
+          "type": "string",
+          "format": "uri"
+        },
+        "informationUri": {
+          "description": "The absolute URI at which information about this version of the tool component can be found.",
+          "type": "string",
+          "format": "uri"
+        },
+        "globalMessageStrings": {
+          "description": "A dictionary, each of whose keys is a resource identifier and each of whose values is a multiformatMessageString object, which holds message strings in plain text and (optionally) Markdown format. The strings can include placeholders, which can be used to construct a message in combination with an arbitrary number of additional string arguments.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/multiformatMessageString"
+          }
+        },
+        "notifications": {
+          "description": "An array of reportingDescriptor objects relevant to the notifications related to the configuration and runtime execution of the tool component.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/reportingDescriptor"
+          }
+        },
+        "rules": {
+          "description": "An array of reportingDescriptor objects relevant to the analysis performed by the tool component.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/reportingDescriptor"
+          }
+        },
+        "taxa": {
+          "description": "An array of reportingDescriptor objects relevant to the definitions of both standalone and tool-defined taxonomies.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/reportingDescriptor"
+          }
+        },
+        "locations": {
+          "description": "An array of the artifactLocation objects associated with the tool component.",
+          "type": "array",
+          "minItems": 0,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/artifactLocation"
+          }
+        },
+        "language": {
+          "description": "The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter lowercase language code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code associated with a country or region). The casing is recommended but not required (in order for this data to conform to RFC5646).",
+          "type": "string",
+          "default": "en-US",
+          "pattern": "^[a-zA-Z]{2}|^[a-zA-Z]{2}-[a-zA-Z]{2}?$"
+        },
+        "contents": {
+          "description": "The kinds of data contained in this object.",
+          "type": "array",
+          "uniqueItems": true,
+          "default": ["localizedData", "nonLocalizedData"],
+          "items": {
+            "enum": ["localizedData", "nonLocalizedData"]
+          }
+        },
+        "isComprehensive": {
+          "description": "Specifies whether this object contains a complete definition of the localizable and/or non-localizable data for this component, as opposed to including only data that is relevant to the results persisted to this log file.",
+          "type": "boolean",
+          "default": false
+        },
+        "localizedDataSemanticVersion": {
+          "description": "The semantic version of the localized strings defined in this component; maintained by components that provide translations.",
+          "type": "string"
+        },
+        "minimumRequiredLocalizedDataSemanticVersion": {
+          "description": "The minimum value of localizedDataSemanticVersion required in translations consumed by this component; used by components that consume translations.",
+          "type": "string"
+        },
+        "associatedComponent": {
+          "$ref": "#/definitions/toolComponentReference",
+          "description": "The component which is strongly associated with this component. For a translation, this refers to the component which has been translated. For an extension, this is the driver that provides the extension's plugin model."
+        },
+        "translationMetadata": {
+          "$ref": "#/definitions/translationMetadata",
+          "description": "Translation metadata, required for a translation, not populated by other component types."
+        },
+        "supportedTaxonomies": {
+          "description": "An array of toolComponentReference objects to declare the taxonomies supported by the tool component.",
+          "type": "array",
+          "minItems": 0,
+          "uniqueItems": true,
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/toolComponentReference"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the tool component."
+        }
+      },
+      "required": ["name"]
+    },
+    "toolComponentReference": {
+      "description": "Identifies a particular toolComponent object, either the driver or an extension.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "The 'name' property of the referenced toolComponent.",
+          "type": "string"
+        },
+        "index": {
+          "description": "An index into the referenced toolComponent in tool.extensions.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "guid": {
+          "description": "The 'guid' property of the referenced toolComponent.",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the toolComponentReference."
+        }
+      }
+    },
+    "translationMetadata": {
+      "description": "Provides additional metadata related to translation.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "The name associated with the translation metadata.",
+          "type": "string"
+        },
+        "fullName": {
+          "description": "The full name associated with the translation metadata.",
+          "type": "string"
+        },
+        "shortDescription": {
+          "$ref": "#/definitions/multiformatMessageString",
+          "description": "A brief description of the translation metadata."
+        },
+        "fullDescription": {
+          "$ref": "#/definitions/multiformatMessageString",
+          "description": "A comprehensive description of the translation metadata."
+        },
+        "downloadUri": {
+          "description": "The absolute URI from which the translation metadata can be downloaded.",
+          "type": "string",
+          "format": "uri"
+        },
+        "informationUri": {
+          "description": "The absolute URI from which information related to the translation metadata can be downloaded.",
+          "type": "string",
+          "format": "uri"
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the translation metadata."
+        }
+      },
+      "required": ["name"]
+    },
+    "versionControlDetails": {
+      "description": "Specifies the information necessary to retrieve a desired revision from a version control system.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repositoryUri": {
+          "description": "The absolute URI of the repository.",
+          "type": "string",
+          "format": "uri"
+        },
+        "revisionId": {
+          "description": "A string that uniquely and permanently identifies the revision within the repository.",
+          "type": "string"
+        },
+        "branch": {
+          "description": "The name of a branch containing the revision.",
+          "type": "string"
+        },
+        "revisionTag": {
+          "description": "A tag that has been applied to the revision.",
+          "type": "string"
+        },
+        "asOfTimeUtc": {
+          "description": "A Coordinated Universal Time (UTC) date and time that can be used to synchronize an enlistment to the state of the repository at that time.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "mappedTo": {
+          "$ref": "#/definitions/artifactLocation",
+          "description": "The location in the local file system to which the root of the repository was mapped at the time of the analysis."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the version control details."
+        }
+      },
+      "required": ["repositoryUri"]
+    },
+    "webRequest": {
+      "description": "Describes an HTTP request.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "index": {
+          "description": "The index within the run.webRequests array of the request object associated with this result.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "protocol": {
+          "description": "The request protocol. Example: 'http'.",
+          "type": "string"
+        },
+        "version": {
+          "description": "The request version. Example: '1.1'.",
+          "type": "string"
+        },
+        "target": {
+          "description": "The target of the request.",
+          "type": "string"
+        },
+        "method": {
+          "description": "The HTTP method. Well-known values are 'GET', 'PUT', 'POST', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS', 'TRACE', 'CONNECT'.",
+          "type": "string"
+        },
+        "headers": {
+          "description": "The request headers.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "parameters": {
+          "description": "The request parameters.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "body": {
+          "$ref": "#/definitions/artifactContent",
+          "description": "The body of the request."
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the request."
+        }
+      }
+    },
+    "webResponse": {
+      "description": "Describes the response to an HTTP request.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "index": {
+          "description": "The index within the run.webResponses array of the response object associated with this result.",
+          "type": "integer",
+          "default": -1,
+          "minimum": -1
+        },
+        "protocol": {
+          "description": "The response protocol. Example: 'http'.",
+          "type": "string"
+        },
+        "version": {
+          "description": "The response version. Example: '1.1'.",
+          "type": "string"
+        },
+        "statusCode": {
+          "description": "The response status code. Example: 451.",
+          "type": "integer"
+        },
+        "reasonPhrase": {
+          "description": "The response reason. Example: 'Not found'.",
+          "type": "string"
+        },
+        "headers": {
+          "description": "The response headers.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "body": {
+          "$ref": "#/definitions/artifactContent",
+          "description": "The body of the response."
+        },
+        "noResponseReceived": {
+          "description": "Specifies whether a response was received from the server.",
+          "type": "boolean",
+          "default": false
+        },
+        "properties": {
+          "$ref": "#/definitions/propertyBag",
+          "description": "Key/value pairs that provide additional information about the response."
+        }
+      }
+    }
+  },
+  "description": "Static Analysis Results Format (SARIF) Version 2.1.0 JSON Schema: a standard format for the output of static analysis tools.",
+  "properties": {
+    "$schema": {
+      "description": "The URI of the JSON schema corresponding to the version.",
+      "type": "string",
+      "format": "uri"
+    },
+    "version": {
+      "description": "The SARIF format version of this log file.",
+      "enum": ["2.1.0"]
+    },
+    "runs": {
+      "description": "The set of runs contained in this log file.",
+      "type": "array",
+      "minItems": 0,
+      "uniqueItems": false,
+      "items": {
+        "$ref": "#/definitions/run"
+      }
+    },
+    "inlineExternalProperties": {
+      "description": "References to external property files that share data between runs.",
+      "type": "array",
+      "minItems": 0,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/definitions/externalProperties"
+      }
+    },
+    "properties": {
+      "$ref": "#/definitions/propertyBag",
+      "description": "Key/value pairs that provide additional information about the log file."
+    }
+  },
+  "required": ["version", "runs"],
+  "title": "Static Analysis Results Format (SARIF) Version 2.1.0 JSON Schema",
+  "type": "object"
+}

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -1,0 +1,368 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the SARIF 2.1.0 finding renderer.
+
+The renderer is a pure function over the Report dataclass.  We build
+synthetic Reports that selectively trigger each rule, render SARIF,
+parse the JSON, and validate it against the bundled SARIF 2.1.0 schema.
+
+The schema lives in tests/fixtures/sarif/ so CI is hermetic — no
+network calls during pytest."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+import pqc_readiness as pr
+from conftest import FIXTURES
+
+SCHEMA_PATH = FIXTURES / "sarif" / "sarif-2.1.0.schema.json"
+
+
+def _load_schema() -> dict[str, Any]:
+    return json.loads(SCHEMA_PATH.read_text())
+
+
+def _validate(instance: dict[str, Any]) -> None:
+    """Validate a SARIF log against the bundled 2.1.0 schema.
+
+    The schema is self-contained Draft-07; no external $ref resolution
+    is required, so a plain Draft7Validator is enough."""
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = _load_schema()
+    jsonschema.Draft7Validator(schema).validate(instance)
+
+
+def _empty_report() -> pr.Report:
+    """A Report with no triggering conditions — every rule should be
+    silent.  Used as the base for selectively enabling one rule at a
+    time."""
+    return pr.Report(
+        generated_at="2026-04-28T12:00:00+00:00",
+        hostname="testhost.example",
+        os="Fedora Linux 44",
+        arch="x86_64",
+    )
+
+
+def _full_trigger_report() -> pr.Report:
+    """A Report that trips every rule at once — used for the all-rules-
+    fire test and for the schema-validation smoke test."""
+    return pr.Report(
+        generated_at="2026-04-28T12:00:00+00:00",
+        hostname="testhost.example",
+        os="Fedora Linux 44",
+        arch="x86_64",
+        openssl={
+            "available": True,
+            "version": "OpenSSL 3.0.0",
+            "pqc_native": False,
+            "kem_algorithms": ["ML-KEM-768"],
+            "sig_algorithms": ["ML-DSA-65", "SLH-DSA-SHA2-128s"],
+            "upgrade_path": {"recommendation": "upgrade to OpenSSL 3.5"},
+        },
+        fips={"kernel": True, "openssl_provider": None},
+        fips_pqc_conflict={"in_conflict": True, "explanation": "FIPS conflict"},
+        isa_tier="poor",
+        isa_score=0,
+        isa_reason="no PQC-relevant SIMD detected",
+        replace_required=True,
+        trust_store={
+            "available": True,
+            "scanned_dirs": ["/etc/pki/ca-trust/extracted/pem"],
+            "total_certs": 142,
+            "pqc_certs": 0,
+            "hybrid_certs": 0,
+        },
+        accelerators=[
+            {
+                "kind": "network_hsm",
+                "name": "Test Network HSM",
+                "detail": "client config present",
+                "pqc_capable": False,
+            },
+        ],
+    )
+
+
+def test_render_sarif_top_level_shape() -> None:
+    log = json.loads(pr.render_sarif(_empty_report()))
+    assert log["version"] == "2.1.0"
+    assert log["$schema"].endswith("sarif-2.1.0.json")
+    runs = log["runs"]
+    assert len(runs) == 1
+    driver = runs[0]["tool"]["driver"]
+    assert driver["name"] == "pqc-readiness"
+    assert driver["version"] == pr.SCRIPT_VERSION
+    # Every rule from RULE_SPECS must be advertised in the driver
+    # descriptor regardless of whether any result references it.
+    rule_ids = [r["id"] for r in driver["rules"]]
+    assert rule_ids == [s.id for s in pr.RULE_SPECS]
+
+
+def test_render_sarif_empty_report_has_no_results() -> None:
+    log = json.loads(pr.render_sarif(_empty_report()))
+    assert log["runs"][0]["results"] == []
+    _validate(log)
+
+
+def test_render_sarif_rules_have_required_metadata() -> None:
+    log = json.loads(pr.render_sarif(_empty_report()))
+    rules = log["runs"][0]["tool"]["driver"]["rules"]
+    assert len(rules) == 6
+    expected_ids = {
+        "pqc-001-openssl-pre-3.5",
+        "pqc-002-fips-pqc-conflict",
+        "pqc-003-no-pqc-isa-support",
+        "pqc-004-classical-only-trust-store",
+        "pqc-005-slh-dsa-in-tls-context",
+        "pqc-006-no-network-hsm-pqc-firmware",
+    }
+    assert {r["id"] for r in rules} == expected_ids
+    for r in rules:
+        assert r["shortDescription"]["text"]
+        assert r["fullDescription"]["text"]
+        assert r["helpUri"].startswith("https://")
+        assert r["defaultConfiguration"]["level"] in {"error", "warning", "note"}
+
+
+def test_render_sarif_full_trigger_report_validates_against_schema() -> None:
+    log = json.loads(pr.render_sarif(_full_trigger_report()))
+    _validate(log)
+    results = log["runs"][0]["results"]
+    rule_ids = {r["ruleId"] for r in results}
+    assert rule_ids == {s.id for s in pr.RULE_SPECS}
+
+
+def test_render_sarif_run_properties_carry_host_context() -> None:
+    log = json.loads(pr.render_sarif(_empty_report()))
+    props = log["runs"][0]["properties"]
+    assert props["host:hostname"] == "testhost.example"
+    assert props["host:os"] == "Fedora Linux 44"
+    assert props["host:arch"] == "x86_64"
+    assert props["tool:version"] == pr.SCRIPT_VERSION
+
+
+# ----- per-rule firing tests ------------------------------------------------
+
+
+def test_pqc_001_fires_when_openssl_below_3_5() -> None:
+    r = _empty_report()
+    r.openssl = {
+        "available": True,
+        "version": "OpenSSL 3.0.0",
+        "pqc_native": False,
+    }
+    findings = pr.build_findings(r)
+    ids = [f.rule_id for f in findings]
+    assert "pqc-001-openssl-pre-3.5" in ids
+
+
+def test_pqc_001_silent_when_openssl_native_pqc() -> None:
+    r = _empty_report()
+    r.openssl = {
+        "available": True,
+        "version": "OpenSSL 3.5.5",
+        "pqc_native": True,
+    }
+    findings = pr.build_findings(r)
+    assert all(f.rule_id != "pqc-001-openssl-pre-3.5" for f in findings)
+
+
+def test_pqc_001_silent_when_openssl_unavailable() -> None:
+    r = _empty_report()
+    r.openssl = {"available": False, "reason": "openssl not on PATH"}
+    findings = pr.build_findings(r)
+    assert all(f.rule_id != "pqc-001-openssl-pre-3.5" for f in findings)
+
+
+def test_pqc_002_fires_on_fips_pqc_conflict() -> None:
+    r = _empty_report()
+    r.fips_pqc_conflict = {
+        "in_conflict": True,
+        "explanation": "kernel FIPS + non-FIPS PQC provider",
+    }
+    findings = pr.build_findings(r)
+    fc = [f for f in findings if f.rule_id == "pqc-002-fips-pqc-conflict"]
+    assert len(fc) == 1
+    assert fc[0].level == "error"
+    assert "non-FIPS" in fc[0].message
+
+
+def test_pqc_002_silent_when_no_conflict() -> None:
+    r = _empty_report()
+    r.fips_pqc_conflict = {"in_conflict": False, "explanation": "ok"}
+    findings = pr.build_findings(r)
+    assert all(f.rule_id != "pqc-002-fips-pqc-conflict" for f in findings)
+
+
+def test_pqc_003_fires_when_replace_required() -> None:
+    r = _empty_report()
+    r.isa_tier = "poor"
+    r.replace_required = True
+    findings = pr.build_findings(r)
+    isa = [f for f in findings if f.rule_id == "pqc-003-no-pqc-isa-support"]
+    assert len(isa) == 1
+    assert isa[0].properties["isa:tier"] == "poor"
+
+
+def test_pqc_003_silent_when_isa_acceptable() -> None:
+    r = _empty_report()
+    r.isa_tier = "good"
+    r.replace_required = False
+    findings = pr.build_findings(r)
+    assert all(f.rule_id != "pqc-003-no-pqc-isa-support" for f in findings)
+
+
+def test_pqc_004_fires_on_classical_only_trust_store() -> None:
+    r = _empty_report()
+    r.trust_store = {
+        "available": True,
+        "scanned_dirs": ["/etc/pki"],
+        "total_certs": 100,
+        "pqc_certs": 0,
+        "hybrid_certs": 0,
+    }
+    findings = pr.build_findings(r)
+    ts = [f for f in findings if f.rule_id == "pqc-004-classical-only-trust-store"]
+    assert len(ts) == 1
+    assert ts[0].level == "note"
+    assert ts[0].properties["trust_store:total_certs"] == 100
+
+
+def test_pqc_004_silent_when_trust_store_has_pqc() -> None:
+    r = _empty_report()
+    r.trust_store = {
+        "available": True,
+        "scanned_dirs": ["/etc/pki"],
+        "total_certs": 100,
+        "pqc_certs": 1,
+        "hybrid_certs": 0,
+    }
+    findings = pr.build_findings(r)
+    assert all(
+        f.rule_id != "pqc-004-classical-only-trust-store" for f in findings
+    )
+
+
+def test_pqc_004_silent_when_trust_store_not_scanned() -> None:
+    """If --scan-trust-store was not requested, the trust_store dict is
+    empty and the rule must NOT fire — the absence of evidence is not
+    evidence of a classical-only store."""
+    r = _empty_report()
+    r.trust_store = {}
+    findings = pr.build_findings(r)
+    assert all(
+        f.rule_id != "pqc-004-classical-only-trust-store" for f in findings
+    )
+
+
+def test_pqc_004_silent_when_trust_store_empty() -> None:
+    """A scanned trust store with zero readable certs should not fire
+    the rule — there is nothing to characterise as classical-only."""
+    r = _empty_report()
+    r.trust_store = {
+        "available": True,
+        "scanned_dirs": [],
+        "total_certs": 0,
+        "pqc_certs": 0,
+        "hybrid_certs": 0,
+    }
+    findings = pr.build_findings(r)
+    assert all(
+        f.rule_id != "pqc-004-classical-only-trust-store" for f in findings
+    )
+
+
+def test_pqc_005_fires_when_slh_dsa_exposed() -> None:
+    r = _empty_report()
+    r.openssl = {
+        "available": True,
+        "version": "OpenSSL 3.5.5",
+        "pqc_native": True,
+        "sig_algorithms": ["ML-DSA-65", "SLH-DSA-SHA2-128s", "SLH-DSA-SHAKE-128f"],
+    }
+    findings = pr.build_findings(r)
+    slh = [f for f in findings if f.rule_id == "pqc-005-slh-dsa-in-tls-context"]
+    assert len(slh) == 1
+    algos = slh[0].properties["openssl:slh_dsa_algorithms"]
+    assert algos == sorted(algos)
+    assert all(a.startswith("SLH-DSA") for a in algos)
+
+
+def test_pqc_005_silent_when_only_ml_dsa_exposed() -> None:
+    r = _empty_report()
+    r.openssl = {
+        "available": True,
+        "version": "OpenSSL 3.5.5",
+        "pqc_native": True,
+        "sig_algorithms": ["ML-DSA-65", "ML-DSA-87"],
+    }
+    findings = pr.build_findings(r)
+    assert all(f.rule_id != "pqc-005-slh-dsa-in-tls-context" for f in findings)
+
+
+def test_pqc_006_fires_for_non_pqc_network_hsm() -> None:
+    r = _empty_report()
+    r.accelerators = [
+        {
+            "kind": "network_hsm",
+            "name": "Acme NetworkHSM",
+            "pqc_capable": False,
+        },
+    ]
+    findings = pr.build_findings(r)
+    hsm = [f for f in findings if f.rule_id == "pqc-006-no-network-hsm-pqc-firmware"]
+    assert len(hsm) == 1
+    assert "Acme NetworkHSM" in hsm[0].properties["hsm:network_hsm_names"]
+
+
+def test_pqc_006_silent_when_network_hsm_is_pqc_capable() -> None:
+    r = _empty_report()
+    r.accelerators = [
+        {
+            "kind": "network_hsm",
+            "name": "PQC Network HSM",
+            "pqc_capable": True,
+        },
+    ]
+    findings = pr.build_findings(r)
+    assert all(
+        f.rule_id != "pqc-006-no-network-hsm-pqc-firmware" for f in findings
+    )
+
+
+def test_pqc_006_silent_when_local_hsm_only() -> None:
+    """Local PCI HSMs are scoped under pqc-003 (replace_required) and
+    must not trigger the network-HSM rule."""
+    r = _empty_report()
+    r.accelerators = [
+        {"kind": "hsm", "name": "Local HSM", "pqc_capable": False},
+    ]
+    findings = pr.build_findings(r)
+    assert all(
+        f.rule_id != "pqc-006-no-network-hsm-pqc-firmware" for f in findings
+    )
+
+
+def test_findings_are_deterministic() -> None:
+    """The order of findings must match RULE_SPECS so SARIF
+    `ruleIndex` values are stable across runs on the same host."""
+    r = _full_trigger_report()
+    a = [f.rule_id for f in pr.build_findings(r)]
+    b = [f.rule_id for f in pr.build_findings(r)]
+    assert a == b
+    assert a == [s.id for s in pr.RULE_SPECS]
+
+
+def test_sarif_result_rule_index_matches_driver_rules() -> None:
+    """SARIF 2.1.0 §3.27.5: a result's `ruleIndex` is an index into
+    `tool.driver.rules`.  Mismatched indices break every consumer that
+    looks up rule metadata via the index path."""
+    log = json.loads(pr.render_sarif(_full_trigger_report()))
+    rules = log["runs"][0]["tool"]["driver"]["rules"]
+    for result in log["runs"][0]["results"]:
+        idx = result["ruleIndex"]
+        assert rules[idx]["id"] == result["ruleId"]


### PR DESCRIPTION
## Summary

- Adds a `--sarif` flag that emits SARIF 2.1.0 (OASIS) for the host-level findings the report already characterises.
- Six rules are defined: `pqc-001-openssl-pre-3.5`, `pqc-002-fips-pqc-conflict`, `pqc-003-no-pqc-isa-support`, `pqc-004-classical-only-trust-store`, `pqc-005-slh-dsa-in-tls-context`, `pqc-006-no-network-hsm-pqc-firmware`.  Each carries `shortDescription`, `fullDescription`, `helpUri`, and a default `level` (`error` / `warning` / `note`).
- Host context (hostname, OS, arch, the values that triggered the rule) ships under `result.properties` and `run.properties` since this is host-scope analysis, not file-scope; per SARIF 2.1.0 §3.27 only `message` is required on a `result`.
- Renderer is a pure function over the existing `Report` dataclass — adding a new rule means appending one entry to `RULE_SPECS` plus a small predicate in `build_findings`.
- Output validates against the SARIF 2.1.0 schema; the schema is bundled at `tests/fixtures/sarif/sarif-2.1.0.schema.json` so CI is hermetic.

Closes #7.

## Test plan

- [x] `pytest tests/` — 204 passed locally (23 new).
- [x] `mypy --strict pqc_readiness.py`
- [x] `ruff check pqc_readiness.py tests/`
- [x] `scripts/check-no-third-party-refs.sh`
- [x] Schema validation against bundled SARIF 2.1.0 schema (Draft-07).
- [x] Per-rule firing-vs-silent tests for each of pqc-001..pqc-006.
- [x] Empty `trust_store` (rule pqc-004) verified silent — absence of evidence does not fire the rule.
- [x] Determinism of finding order (so `ruleIndex` is stable).