### PR TITLE
docs: document every flag and JSON field in README; enforce in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,6 @@ jobs:
 
       - name: pytest
         run: pytest tests/ -q
+
+      - name: README documents every --help flag
+        run: bash scripts/check-readme-flags.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,3 +58,36 @@ Run locally before committing:
 
 Exit codes: 0 clean, 1 forbidden references found, 2 configuration
 error.
+
+## README is part of the feature
+
+`README.md` is the discovery surface for this tool. A flag, top-level
+JSON field, output format, or behavioural change that is not in the
+README does not exist as far as a customer reading the repo is
+concerned. PRs that add or change any of the following must update the
+README in the same PR:
+
+- Any new or renamed flag accepted by `pqc_readiness.py` (anything that
+  appears in `./pqc_readiness.py --help`).
+- Any new or renamed top-level key in the `--json`, `--ansible`,
+  `--cbom`, `--sarif`, `--recommend`, or `--aggregate` outputs.
+- Any new output format (a new `--<something>` that emits a distinct
+  serialization).
+- Any change to the `--help` text that affects the documented behaviour
+  of an existing flag.
+- Any change to exit codes.
+
+The README must, at minimum, name the flag or field and describe its
+purpose in one sentence. Detailed reference may live in a linked file
+under `docs/` (for example `docs/scope.md`,
+`docs/recommendation-policies.md`), but the README must point at it.
+
+Verifying coverage locally:
+
+    ./pqc_readiness.py --help > /tmp/help.txt
+    ./pqc_readiness.py --json > /tmp/sample.json
+    # Each flag in /tmp/help.txt must appear in README.md.
+    # Each top-level key in /tmp/sample.json must appear in README.md
+    # or in a doc the README cross-references.
+
+PR review will reject feature changes whose README delta is empty.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ IMAGE ?= pqc-readiness:dev
 IMAGE_UBI10 ?= pqc-readiness:ubi10
 IMAGE_DEBIAN ?= pqc-readiness:debian
 
-.PHONY: help test lint typecheck check container container-build container-ubi10 container-debian clean
+.PHONY: help test lint typecheck check check-readme container container-build container-ubi10 container-debian clean
 
 help:
 	@grep -E '^[a-zA-Z_-]+:.*##' Makefile | awk -F':.*##' '{printf "  %-20s %s\n", $$1, $$2}'
@@ -25,6 +25,9 @@ typecheck: ## mypy strict
 	$(MYPY) --strict pqc_readiness.py
 
 check: lint typecheck test ## All of the above
+
+check-readme: ## Verify README.md documents every --help flag
+	@bash scripts/check-readme-flags.sh
 
 container-build: container-ubi10 ## Alias for container-ubi10 (back-compat)
 

--- a/README.md
+++ b/README.md
@@ -45,11 +45,216 @@ DaemonSet on OpenShift.
 ./pqc_readiness.py --bench            # include OpenSSL microbench
 ./pqc_readiness.py --json             # stable JSON for aggregation
 ./pqc_readiness.py --cbom             # CycloneDX 1.6 CBOM JSON (NIST IR 8547)
+./pqc_readiness.py --sarif            # SARIF 2.1.0 findings (OASIS)
 ./pqc_readiness.py --markdown         # markdown for tickets
+./pqc_readiness.py --recommend        # policy-aware algorithm recommendation
 ./pqc_readiness.py --ansible          # ansible_facts wrapper
 ./pqc_readiness.py --aggregate ./out  # roll up many --save outputs
 ./pqc_readiness.py --version          # script + JSON schema versions
 ```
+
+## Flags
+
+Every flag listed by `./pqc_readiness.py --help` is documented below.
+The list is grouped by purpose; the `--help` text remains the
+authoritative one-line summary.
+
+### Output format
+
+| Flag | Purpose |
+| --- | --- |
+| `--json` | Emit the stable JSON schema (see [JSON output](#json-output---json)). |
+| `--markdown` | Emit a markdown report suitable for pasting into a ticket. |
+| `--cbom` | Emit a CycloneDX 1.6 Cryptographic Bill of Materials (see [CBOM output](#cbom-output---cbom)). |
+| `--sarif` | Emit SARIF 2.1.0 findings for security pipelines (see [SARIF output](#sarif-output---sarif)). |
+| `--ansible` | Wrap the JSON schema in `{ansible_facts: {pqc_readiness: ...}}` and exit 0. Intended for `ansible.builtin.set_fact`. |
+
+`--json`, `--cbom`, and `--sarif` are mutually exclusive views over the
+same probe run. The default (no flag) is the human-readable text
+report.
+
+### Benchmarking
+
+| Flag | Purpose |
+| --- | --- |
+| `--bench` | Run the PQC + classical OpenSSL microbenchmark and include results in the output. |
+| `--bench-tls` | Run a loopback TLS 1.3 handshake benchmark covering classical, hybrid, and pure-PQC groups. |
+| `--threads N` | Add an N-way scaling test alongside the single-thread benchmark. |
+| `--seconds N` | Override the per-operation benchmark duration. Larger values reduce variance at the cost of run time. |
+
+Benchmark results land under the `benchmark` and
+`benchmark_tls_handshake` top-level JSON keys. Without `--bench` /
+`--bench-tls`, those keys are still present but empty.
+
+### Recommendation engine
+
+| Flag | Purpose |
+| --- | --- |
+| `--recommend` | Emit a host-specific PQC algorithm recommendation under the selected policy and role, instead of the readiness report. |
+| `--policy {cnsa-2.0,nist-civilian,eu-anssi-bsi,commercial,auto}` | Compliance context for `--recommend`. `auto` (default) emits all policies side by side. |
+| `--role {tls-server,tls-client,signing-service,firmware-signing}` | Role for `--recommend`. Only `tls-server` is fully implemented; other roles return a stub response. |
+
+The full policy-to-preference mapping, the issuing authority for each
+policy, and the source documents are catalogued in
+[`docs/recommendation-policies.md`](docs/recommendation-policies.md).
+Updating a policy is a single-place edit in the `POLICY_PREFERENCES`
+table inside `pqc_readiness.py`; the engine itself does not change.
+
+`--recommend` combines with `--json` to produce a machine-readable
+recommendation document with top-level keys `role`, `mode`, `hostname`,
+`generated_at`, and `recommendations`. This is a different schema from
+the readiness `--json`; see [JSON output](#json-output---json).
+
+### Inventory and host probes
+
+| Flag | Purpose |
+| --- | --- |
+| `--scan-trust-store` | Walk system trust-store directories and count PQC / hybrid certificates. Slower than the default probe; opt in when an inventory of the trust anchors is needed. |
+| `--scan-packages` | Enumerate installed packages with bundled crypto. Branches on family: `rpm -qa` (rhel/suse), `dpkg-query -W` (debian), `pacman -Q` (arch), `apk info -v` (alpine). All four parsers normalise to the same `[{name, version}, ...]` shape. |
+| `--host-mount PATH` | Prefix for `/proc /sys /dev /etc` reads. Used by the OpenShift DaemonSet pattern: the host filesystem is mounted at `/host` inside the container, and `--host-mount /host` makes the probe inspect the node, not the container. |
+
+Without these flags the probe stays in the fast path and skips the
+trust-store walk and the package enumeration.
+
+### Verbosity, gating, and persistence
+
+| Flag | Purpose |
+| --- | --- |
+| `--check {excellent,good,marginal,poor,cnsa-2.0}` | Exit 4 if the verdict is below the named tier, or if `cnsa-2.0` is selected and the host is not CNSA 2.0 compliant. Designed for CI gating. |
+| `--save` | Write JSON to `~/.cache/pqc-readiness/`. The fleet aggregation path reads exactly this directory layout. |
+| `--quiet` | Print only the verdict line (e.g. `EXCELLENT - software PQC at production speed`). |
+| `--no-color` | Disable ANSI colour in human-readable output. Auto-disabled when stdout is not a TTY. |
+
+### Aggregation
+
+| Flag | Purpose |
+| --- | --- |
+| `--aggregate DIR` | Aggregate every `*.json` in `DIR` into a fleet rollup; the program exits when done and ignores all other flags. |
+| `--aggregate-format {json,csv}` | Output format for `--aggregate` (default `json`). |
+
+See the [Aggregation](#aggregation-1) section for the rollup schema.
+
+### Miscellaneous
+
+| Flag | Purpose |
+| --- | --- |
+| `--version` | Print the script version and the JSON schema version, then exit. |
+| `-h`, `--help` | Print the help text and exit. |
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Excellent — dedicated PQC silicon OR optimized SIMD + ample RAM. |
+| 1 | Good — software PQC fast enough for production. |
+| 2 | Marginal — works, but plan for an accelerator at scale. |
+| 3 | Poor — software-only and too slow for production. |
+| 4 | `--check` threshold not met (TIER below floor, or `cnsa-2.0` not compliant). |
+
+## JSON output (`--json`)
+
+`--json` emits a stable, schema-versioned document. The `schema_version`
+key changes only when fields are renamed or removed; additive changes
+keep the same version. Aggregation refuses to merge files whose
+`schema_version` does not match the rollup version.
+
+| Top-level key | Description |
+| --- | --- |
+| `schema_version` | Stable schema version string. Bumped on rename/remove, not on additive changes. |
+| `generated_at` | ISO 8601 UTC timestamp of the probe run. |
+| `hostname` | Host's reported hostname. |
+| `os` | OS family token (`linux`, `darwin`). |
+| `arch` | CPU architecture (`x86_64`, `aarch64`, `s390x`, …). |
+| `cpu_model` | CPU model string from `/proc/cpuinfo` or `sysctl`. |
+| `cpu_freq_mhz` | Reported CPU base frequency. |
+| `cores_logical` | Logical core count (SMT siblings included). |
+| `cores_physical` | Physical core count. |
+| `mem_total_gb` | Total system memory in GiB. |
+| `mem_avail_gb` | Available memory in GiB at probe time. |
+| `isa_features` | Map of ISA feature flags relevant to PQC (AVX-512 family, ARMv8 crypto, CPACF MSA, …). |
+| `isa_score` | Numeric ISA score backing the tier classification. |
+| `isa_tier` | Coarse ISA tier (`excellent` / `good` / `marginal` / `poor`). |
+| `isa_reason` | Human-readable explanation for the ISA tier. |
+| `accelerators` | List of detected accelerators (HSMs, DPUs, TPMs, QAT, Nitro, …). |
+| `hsm_present_but_not_pqc` | True when an HSM is detected but it does not advertise PQC primitives. |
+| `pkcs11_modules` | PKCS#11 modules discoverable on the host. |
+| `kernel_crypto_hw` | `/proc/crypto` entries backed by hardware drivers. |
+| `ktls_supported` | Whether kernel TLS is available. |
+| `fips` | Kernel FIPS mode and provider state. |
+| `openssl` | Detected OpenSSL version, PQC algorithm exposure, hybrid TLS group list, and `upgrade_path` suggestion. |
+| `tpm_pqc` | TPM presence and any PQC capability advertised. |
+| `memory_bandwidth_gb_s` | Memory bandwidth measurement (null if not measured). |
+| `memory_bandwidth_method` | How the bandwidth value was obtained, or `not-measured`. |
+| `ssh_pqc` | OpenSSH `ssh -Q kex` PQC / hybrid kex availability. |
+| `ipsec_pqc` | strongSwan / Libreswan PQC and hybrid IKE state. |
+| `nss` | NSS PQC algorithm exposure. |
+| `kernel_info` | Kernel version, build flags relevant to crypto, and module list. |
+| `fips_pqc_conflict` | Detected when kernel FIPS is on but PQC is exposed only via a non-FIPS provider. |
+| `cnsa_2_0` | CNSA 2.0 compliance summary (algorithm coverage, hash, FIPS state). |
+| `trust_store` | Trust-store summary (count, PQC-capable count, hybrid count). Populated only when `--scan-trust-store` is set. |
+| `runtime_environment` | How the probe is running (bare metal, container, DaemonSet, …). |
+| `packages` | Installed crypto-bearing packages. Populated only when `--scan-packages` is set. |
+| `replace_required` | Top-level boolean for fleet planning: true when the host cannot run NIST PQC at production speed without an accelerator. |
+| `os_release` | Parsed `/etc/os-release` (id, version, like-chain). |
+| `benchmark` | Microbenchmark results from `--bench`. Empty when `--bench` is not set. |
+| `benchmark_tls_handshake` | TLS 1.3 handshake bench results from `--bench-tls`. Empty when `--bench-tls` is not set. |
+| `pqc_sizes` | Wire-size and key-size constants for the PQC primitives, used by the recommendation engine and by sizing notes in the human report. |
+| `per_algo` | Per-algorithm tier and reasoning (ML-KEM-512/768/1024, ML-DSA-44/65/87, SLH-DSA variants). |
+| `production_estimate` | Estimated handshakes-per-second / sign-per-second per algorithm given the measured benchmark numbers. |
+| `verdict` | Coarse verdict (`excellent` / `good` / `marginal` / `poor`). |
+| `verdict_reason` | One-line explanation for the verdict. |
+| `verdict_caveat` | Caveat string (e.g. `no-bench`) when the verdict was determined without running OpenSSL primitives. |
+| `exit_code` | Numeric exit code the program will return. Mirrors the [Exit codes](#exit-codes) table. |
+
+`--ansible` returns a single top-level key `ansible_facts`, whose value
+is `{pqc_readiness: {…the schema above…}}`.
+
+`--recommend --json` returns a different document with top-level keys
+`role`, `mode`, `hostname`, `generated_at`, and `recommendations`. The
+`recommendations` list contains one object per evaluated policy with
+`policy`, `authority`, `kem`, `signature`, `hash`, `policy_basis`,
+`source`, and `caveats`.
+
+## CBOM output (`--cbom`)
+
+`--cbom` emits a [CycloneDX 1.6](https://cyclonedx.org/docs/1.6/json/)
+Cryptographic Bill of Materials. Each detected source — ISA features,
+accelerators / HSMs / TPMs, OpenSSL KEM and signature algorithms,
+OpenSSL TLS hybrid and pure-PQC groups, OpenSSH PQC kex, IPsec
+implementation, PKCS#11 modules, and the trust-store summary — becomes
+a `cryptographic-asset` component with the appropriate `assetType`,
+`algorithmProperties` (or `protocolProperties` /
+`relatedCryptoMaterialProperties`) where applicable, and a `detectedBy:
+pqc-readiness@<version>` provenance property.
+
+The output validates against the official CycloneDX 1.6 JSON schema and
+is suitable for ingest by any CBOM-aware tooling. NIST IR 8547
+([final](https://csrc.nist.gov/pubs/ir/8547/final)) references CycloneDX
+1.6 as the standard exchange format for cryptographic inventory.
+
+The existing `--json` output is unchanged; the two formats can be
+emitted side by side from the same probe run.
+
+## SARIF output (`--sarif`)
+
+`--sarif` emits [SARIF 2.1.0](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html)
+findings (OASIS standard) so the readiness signal can be consumed by
+the same security pipelines that already ingest SARIF from other
+scanners. Each finding is a rule with a stable id (`pqc-001-…`,
+`pqc-002-…`, …), a short and full description, a `helpUri` pointing at
+`docs/rules/<rule-id>.md`, and a default severity level
+(`warning` / `error`).
+
+Findings cover, among others:
+
+- OpenSSL older than 3.5 (no native PQC).
+- Kernel FIPS mode active but PQC is exposed via a non-FIPS provider.
+- Hybrid TLS groups missing from the OpenSSL build.
+- HSM present but not advertising PQC primitives.
+
+The SARIF document validates against the official SARIF 2.1.0 JSON
+schema. As with `--cbom`, the `--json` schema is unchanged; SARIF is a
+projection over the same probe run.
 
 ## Distribution support
 
@@ -103,7 +308,9 @@ make container           # build both
 the probe daily against the host. `deploy/openshift/daemonset.yaml` is
 the fleet DaemonSet — non-root UID 1001, hostPID, custom SCC dropping
 all capabilities, read-only host bind mounts of `/proc /sys /dev /etc
-/usr/lib/os-release`.
+/usr/lib/os-release`. Inside the DaemonSet the host root is mounted at
+`/host`, and the probe is invoked with `--host-mount /host` so its
+reads target the node, not the container image.
 
 ## Aggregation
 
@@ -120,25 +327,16 @@ pqc_readiness.py --aggregate /var/lib/pqc-readiness --aggregate-format csv  # CS
 Files with mismatched `schema_version` are listed under `skipped` with
 a reason rather than silently merged.
 
-## CBOM output (`--cbom`)
+## Documentation map
 
-`--cbom` emits a [CycloneDX 1.6](https://cyclonedx.org/docs/1.6/json/)
-Cryptographic Bill of Materials. Each detected source — ISA features,
-accelerators / HSMs / TPMs, OpenSSL KEM and signature algorithms,
-OpenSSL TLS hybrid and pure-PQC groups, OpenSSH PQC kex, IPsec
-implementation, PKCS#11 modules, and the trust-store summary — becomes
-a `cryptographic-asset` component with the appropriate `assetType`,
-`algorithmProperties` (or `protocolProperties` /
-`relatedCryptoMaterialProperties`) where applicable, and a `detectedBy:
-pqc-readiness@<version>` provenance property.
-
-The output validates against the official CycloneDX 1.6 JSON schema and
-is suitable for ingest by any CBOM-aware tooling. NIST IR 8547
-([final](https://csrc.nist.gov/pubs/ir/8547/final)) references CycloneDX
-1.6 as the standard exchange format for cryptographic inventory.
-
-The existing `--json` output is unchanged; the two formats can be
-emitted side by side from the same probe run.
+- [`docs/scope.md`](docs/scope.md) — where this project fits in the
+  wider PQC tooling ecosystem; how host-level scanning composes with
+  network, source-code, dependency, and TLS-handshake categories.
+- [`docs/recommendation-policies.md`](docs/recommendation-policies.md) —
+  authority, source documents, and engine-encoded position for every
+  policy reachable through `--policy`.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — third-party product reference
+  policy and the rule that keeps this README in sync with `--help`.
 
 ## License
 

--- a/scripts/check-readme-flags.sh
+++ b/scripts/check-readme-flags.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Verify that every flag printed by `./pqc_readiness.py --help` is
+# documented in README.md.  See the "README is part of the feature"
+# section of CONTRIBUTING.md for the policy.
+#
+# Usage: scripts/check-readme-flags.sh
+# Exit:  0 if every --help flag appears in README.md
+#        1 if any --help flag is missing from README.md
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SCRIPT="$REPO_ROOT/pqc_readiness.py"
+README="$REPO_ROOT/README.md"
+
+if [[ ! -x "$SCRIPT" ]]; then
+  echo "error: $SCRIPT not found or not executable" >&2
+  exit 2
+fi
+if [[ ! -f "$README" ]]; then
+  echo "error: $README not found" >&2
+  exit 2
+fi
+
+# Extract every long-form flag (`--foo`) printed by --help, dedup.
+mapfile -t FLAGS < <(
+  "$SCRIPT" --help \
+    | grep -oE -- '--[a-z][a-z0-9-]+' \
+    | sort -u
+)
+
+missing=()
+for flag in "${FLAGS[@]}"; do
+  if ! grep -qF -- "$flag" "$README"; then
+    missing+=("$flag")
+  fi
+done
+
+if (( ${#missing[@]} > 0 )); then
+  echo "Flags in --help missing from README.md:" >&2
+  printf '  %s\n' "${missing[@]}" >&2
+  echo >&2
+  echo "Update README.md to mention each flag, then re-run:" >&2
+  echo "  make check-readme" >&2
+  exit 1
+fi
+
+echo "OK: every --help flag (${#FLAGS[@]}) appears in README.md."


### PR DESCRIPTION
## Summary

- Sweeps the README to cover every flag printed by `--help` and every top-level JSON key emitted by `--json`. The README had drifted behind a string of feature PRs (CNSA 2.0, hybrid detection, CBOM, recommendation engine, TLS handshake bench, composite signature detection, SARIF); only `--cbom` had a dedicated section before this PR.
- Adds a `make check-readme` target plus a CI step that grep every long-form `--help` flag against `README.md` and fails on divergence, so the gap cannot silently reopen.
- Adds a "README is part of the feature" rule to `CONTRIBUTING.md` enumerating the surface (flags, top-level JSON fields, output formats, exit codes, behavioural changes in `--help`) that requires a README delta in the same PR.

## Acceptance criteria (from #25)

- [x] README documents every flag listed by `./pqc_readiness.py --help` at the time of pickup. The repo grep is empty: `scripts/check-readme-flags.sh` reports `OK: every --help flag (23) appears in README.md.`
- [x] Every top-level JSON field emitted by `--json` is described in the README (single table under "JSON output").
- [x] README cross-references `docs/scope.md` from "Scope" (already wired) and `docs/recommendation-policies.md` from a new "Recommendation engine" section.
- [x] CONTRIBUTING.md gains "README is part of the feature".
- [x] Nice-to-have CI check / `make check-readme` target — added, stayed simple (one shell script + one Make target + one CI step).

## "At time of pickup" scoping

`#6` (SPDX) was in flight when this issue was picked up, with no merge and no documented surface in `--help` yet, so the SPDX flag and JSON additions are out of scope here per the issue body. The follow-up PR for `#6` is responsible for its own README delta — `make check-readme` and the new CONTRIBUTING.md rule will fail review there if the delta is empty.

## Test plan

- [x] `make check-readme` — passes (23 / 23 flags covered).
- [x] `bash scripts/check-no-third-party-refs.sh` — clean.
- [x] `python3 -m pytest tests/ -q` — 217 passed.
- [x] `ruff check pqc_readiness.py tests/` — clean.
- [x] `mypy --strict pqc_readiness.py` — clean.
- [x] Manual: every key returned by `./pqc_readiness.py --json` is grepped against README.md — no misses.

CodeRabbit review on uncommitted changes was attempted but the org hourly cap was hit ("usage-based add-on" gate); CodeRabbit's PR-side review will run on this PR.

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)