### PR TITLE
feat: add SPDX 3.0 JSON-LD output (--spdx)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ DaemonSet on OpenShift.
 ./pqc_readiness.py --bench            # include OpenSSL microbench
 ./pqc_readiness.py --json             # stable JSON for aggregation
 ./pqc_readiness.py --cbom             # CycloneDX 1.6 CBOM JSON (NIST IR 8547)
+./pqc_readiness.py --spdx             # SPDX 3.0 JSON-LD (Security profile)
 ./pqc_readiness.py --sarif            # SARIF 2.1.0 findings (OASIS)
 ./pqc_readiness.py --markdown         # markdown for tickets
 ./pqc_readiness.py --recommend        # policy-aware algorithm recommendation
@@ -66,12 +67,13 @@ authoritative one-line summary.
 | `--json` | Emit the stable JSON schema (see [JSON output](#json-output---json)). |
 | `--markdown` | Emit a markdown report suitable for pasting into a ticket. |
 | `--cbom` | Emit a CycloneDX 1.6 Cryptographic Bill of Materials (see [CBOM output](#cbom-output---cbom)). |
+| `--spdx` | Emit an SPDX 3.0 JSON-LD document with the Security profile (see [SPDX 3.0 output](#spdx-30-output---spdx)). |
 | `--sarif` | Emit SARIF 2.1.0 findings for security pipelines (see [SARIF output](#sarif-output---sarif)). |
 | `--ansible` | Wrap the JSON schema in `{ansible_facts: {pqc_readiness: ...}}` and exit 0. Intended for `ansible.builtin.set_fact`. |
 
-`--json`, `--cbom`, and `--sarif` are mutually exclusive views over the
-same probe run. The default (no flag) is the human-readable text
-report.
+`--json`, `--cbom`, `--spdx`, and `--sarif` are mutually exclusive views
+over the same probe run. The default (no flag) is the human-readable
+text report.
 
 ### Benchmarking
 
@@ -337,6 +339,34 @@ a reason rather than silently merged.
   policy reachable through `--policy`.
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — third-party product reference
   policy and the rule that keeps this README in sync with `--help`.
+
+## SPDX 3.0 output (`--spdx`)
+
+`--spdx` emits an [SPDX 3.0.1](https://spdx.github.io/spdx-spec/v3.0.1/)
+JSON-LD document with `profileConformance` set to `core`, `software`,
+and `security`. The same canonical asset list that drives `--cbom` is
+projected into:
+
+- one `software_Package` per detected cryptographic asset (algorithm,
+  protocol, related-crypto-material), with `software_primaryPurpose` set
+  to `device` for hardware-execution assets and `library` for software
+  ones,
+- one `software_Package` for the scanned host,
+- one `security_Vulnerability` per finding, plus a
+  `security_VexAffectedVulnAssessmentRelationship` linking each
+  vulnerability to the host package via the VEX `affects` relationship,
+- a top-level `software_Sbom` and `SpdxDocument` that wrap the above.
+
+Detection logic is shared with `--cbom` — both renderers read the same
+`canonical_assets()` pipeline and the same finding rules used by
+`--sarif`, so a new detection rule shows up in every output format
+without per-renderer changes.
+
+The output is JSON-LD: every `type` and property is a term in the
+canonical SPDX 3.0.1 context at
+<https://spdx.org/rdf/3.0.1/spdx-context.jsonld>, and every reference
+(`createdBy`, `element`, `from`, `to`, `security_assessedElement`)
+resolves within the document.
 
 ## License
 

--- a/pqc_readiness.py
+++ b/pqc_readiness.py
@@ -3843,22 +3843,18 @@ def _tier_label(tier: str) -> str:
     return C.wrap(TIER_COLOR.get(tier, ""), tier.upper())
 
 
-# CycloneDX 1.6 CBOM rendering ----------------------------------------------
+# Canonical cryptographic-asset model ----------------------------------------
 #
-# A CBOM (Cryptographic Bill of Materials) is a CycloneDX BOM whose
-# `components` are populated with `cryptographic-asset` entries.  NIST IR
-# 8547 references CycloneDX 1.6 as the standard for cryptographic inventory
-# exchange, so emitting this shape lets downstream PQC-migration tooling
-# ingest pqc-readiness output without writing a bespoke translator.
-#
-# The mapping of pqc-readiness Report fields to crypto-asset entries is
-# kept in small declarative tables below so it is auditable: each table
-# row is one `(input field, asset shape)` pair, and the renderer simply
-# iterates the report.
+# Both --cbom (CycloneDX 1.6) and --spdx (SPDX 3.0 JSON-LD) project from
+# the same canonical CryptoAsset list, so detection logic lives in one
+# place and the renderers are pure projections.  A single source of
+# truth means a new detection rule shows up in every output format
+# without a renderer-side patch.
 #
 # Refs:
 #   https://cyclonedx.org/docs/1.6/json/  (specVersion 1.6)
 #   https://csrc.nist.gov/pubs/ir/8547/final  (NIST IR 8547)
+#   https://spdx.github.io/spdx-spec/v3.0.1/  (SPDX 3.0.1)
 
 # Implementation platform mapping for CycloneDX algorithmProperties.
 # CycloneDX enumerates a fixed set of `implementationPlatform` values;
@@ -3918,149 +3914,185 @@ def _pqc_parameter_set(name: str) -> str:
     return name
 
 
-def _cbom_provenance() -> list[dict[str, str]]:
-    """The provenance property required by the issue acceptance criteria.
-    Stamped onto every emitted asset so downstream aggregators can tell
-    which tool detected the entry."""
-    return [{"name": "detectedBy", "value": f"pqc-readiness@{SCRIPT_VERSION}"}]
+@dataclass(frozen=True)
+class CryptoAsset:
+    """Canonical cryptographic asset detected on the host.
+
+    Both --cbom (CycloneDX 1.6 cryptographic-asset components) and
+    --spdx (SPDX 3.0 software_Package elements) project from this list,
+    so each detection rule appears in exactly one place.
+
+    The `category` is the detection-source bucket (e.g. "openssl_kem",
+    "ssh_kex_hybrid") — used to label per-format properties so consumers
+    can correlate findings across CBOM and SPDX outputs.
+
+    `asset_type` matches the CycloneDX 1.6 cryptographic-asset enum:
+    "algorithm" | "protocol" | "related-crypto-material".  Renderers
+    omit fields whose values are empty / None."""
+
+    key: str
+    name: str
+    category: str
+    asset_type: str
+    primitive: str = ""
+    execution_environment: str = ""
+    implementation_platform: str = ""
+    protocol_type: str = ""
+    related_material_type: str = ""
+    parameter_set: str = ""
+    nist_category: int | None = None
+    source: str = ""
+    properties: tuple[tuple[str, str], ...] = ()
 
 
-def _cbom_asset(
-    bom_ref: str,
+def _pqc_algorithm_asset(
+    key: str,
     name: str,
-    crypto_props: dict[str, Any],
-    extra_props: list[dict[str, str]] | None = None,
-) -> dict[str, Any]:
-    """Build a CycloneDX 1.6 cryptographic-asset component.  Every asset
-    carries the `detectedBy` provenance tag and may carry extra free-form
-    properties (e.g. `evidence`, `source`) that downstream consumers can
-    surface to operators."""
-    props = _cbom_provenance()
-    if extra_props:
-        props.extend(extra_props)
-    return {
-        "type": "cryptographic-asset",
-        "bom-ref": bom_ref,
-        "name": name,
-        "cryptoProperties": crypto_props,
-        "properties": props,
-    }
+    category: str,
+    primitive: str,
+    source: str,
+) -> CryptoAsset:
+    """A NIST PQC algorithm exposed by a library.  Carries a derived
+    parameterSetIdentifier and nistQuantumSecurityLevel where the
+    algorithm name is in the published FIPS lookup."""
+    pset = _pqc_parameter_set(name)
+    return CryptoAsset(
+        key=key,
+        name=name,
+        category=category,
+        asset_type="algorithm",
+        primitive=primitive,
+        execution_environment="software-plain-ram",
+        parameter_set=pset if pset != name else "",
+        nist_category=_PQC_NIST_CATEGORY.get(name),
+        source=source,
+    )
 
 
-def _cbom_isa_assets(r: Report) -> list[dict[str, Any]]:
-    """Each detected ISA feature becomes a hardware-execution algorithm
-    asset.  Primitive is `other` because an ISA feature accelerates many
-    primitives (Keccak, lattice mul, AES round) rather than implementing
-    one — the human-readable purpose lives in the `purpose` property."""
+def _canonical_isa_assets(r: Report) -> list[CryptoAsset]:
+    """Each detected ISA feature is a hardware-execution algorithm asset.
+    Primitive is `other` because an ISA feature accelerates many primitives
+    (Keccak, lattice mul, AES round) rather than implementing one — the
+    human-readable purpose lives in the `purpose` property."""
     platform_id = _cbom_platform(r.arch)
-    out: list[dict[str, Any]] = []
+    out: list[CryptoAsset] = []
     for flag, info in sorted(r.isa_features.items()):
         out.append(
-            _cbom_asset(
-                bom_ref=f"isa/{flag}",
+            CryptoAsset(
+                key=f"isa/{flag}",
                 name=info.get("name", flag),
-                crypto_props={
-                    "assetType": "algorithm",
-                    "algorithmProperties": {
-                        "primitive": "other",
-                        "executionEnvironment": "hardware",
-                        "implementationPlatform": platform_id,
-                    },
-                },
-                extra_props=[
-                    {"name": "isa:flag", "value": flag},
-                    {"name": "isa:purpose", "value": info.get("purpose", "")},
-                ],
+                category="isa",
+                asset_type="algorithm",
+                primitive="other",
+                execution_environment="hardware",
+                implementation_platform=platform_id,
+                properties=(
+                    ("isa:flag", flag),
+                    ("isa:purpose", info.get("purpose", "")),
+                ),
             )
         )
     return out
 
 
-def _cbom_accelerator_assets(r: Report) -> list[dict[str, Any]]:
+def _canonical_accelerator_assets(r: Report) -> list[CryptoAsset]:
     """HSMs, TPMs, accelerators, DPUs and network HSMs each become a
     hardware-execution algorithm asset.  The detection layer already
     classifies kind/name/detail/pqc_capable; we surface those verbatim
     in extra properties so consumers can filter on them."""
-    out: list[dict[str, Any]] = []
+    platform_id = _cbom_platform(r.arch)
+    out: list[CryptoAsset] = []
     for idx, a in enumerate(r.accelerators):
         kind = a.get("kind", "accelerator")
         name = a.get("name", "")
-        bom_ref = f"accel/{idx}/{kind}"
-        extra = [{"name": "accelerator:kind", "value": str(kind)}]
+        props: list[tuple[str, str]] = [("accelerator:kind", str(kind))]
         detail = a.get("detail")
         if detail:
-            extra.append({"name": "accelerator:detail", "value": str(detail)})
+            props.append(("accelerator:detail", str(detail)))
         if a.get("pqc_capable"):
-            extra.append({"name": "accelerator:pqc_capable", "value": "true"})
+            props.append(("accelerator:pqc_capable", "true"))
         out.append(
-            _cbom_asset(
-                bom_ref=bom_ref,
+            CryptoAsset(
+                key=f"accel/{idx}/{kind}",
                 name=name or kind,
-                crypto_props={
-                    "assetType": "algorithm",
-                    "algorithmProperties": {
-                        "primitive": "other",
-                        "executionEnvironment": "hardware",
-                        "implementationPlatform": _cbom_platform(r.arch),
-                    },
-                },
-                extra_props=extra,
+                category="accelerator",
+                asset_type="algorithm",
+                primitive="other",
+                execution_environment="hardware",
+                implementation_platform=platform_id,
+                properties=tuple(props),
             )
         )
     return out
 
 
-def _cbom_pqc_algorithm_asset(
-    bom_ref: str,
-    name: str,
-    primitive: str,
-    source: str,
-) -> dict[str, Any]:
-    """A NIST PQC algorithm exposed by a library.  Carries
-    parameterSetIdentifier and nistQuantumSecurityLevel where the
-    algorithm name is in the published FIPS lookup."""
-    algo_props: dict[str, Any] = {
-        "primitive": primitive,
-        "executionEnvironment": "software-plain-ram",
-    }
-    pset = _pqc_parameter_set(name)
-    if pset != name:
-        algo_props["parameterSetIdentifier"] = pset
-    cat = _PQC_NIST_CATEGORY.get(name)
-    if cat is not None:
-        algo_props["nistQuantumSecurityLevel"] = cat
-    return _cbom_asset(
-        bom_ref=bom_ref,
-        name=name,
-        crypto_props={
-            "assetType": "algorithm",
-            "algorithmProperties": algo_props,
-        },
-        extra_props=[{"name": "source", "value": source}],
-    )
+def _canonical_tpm_assets(r: Report) -> list[CryptoAsset]:
+    tpm = r.tpm_pqc or {}
+    if not tpm.get("present"):
+        return []
+    return [
+        CryptoAsset(
+            key="tpm/pqc",
+            name="TPM PQC capability",
+            category="tpm",
+            asset_type="algorithm",
+            primitive="other",
+            execution_environment="hardware",
+            implementation_platform=_cbom_platform(r.arch),
+            properties=(
+                (
+                    "tpm:pqc_advertised",
+                    "true" if tpm.get("pqc_advertised") else "false",
+                ),
+                ("tpm:note", str(tpm.get("note", ""))),
+            ),
+        )
+    ]
 
 
-def _cbom_openssl_assets(r: Report) -> list[dict[str, Any]]:
+def _canonical_pkcs11_assets(r: Report) -> list[CryptoAsset]:
+    """PKCS#11 is a cryptographic-token API; each loadable module is
+    emitted as a protocol asset with the module path captured in a
+    property so an aggregator can deduplicate identical modules across
+    a fleet."""
+    out: list[CryptoAsset] = []
+    for idx, mod in enumerate(r.pkcs11_modules or []):
+        out.append(
+            CryptoAsset(
+                key=f"pkcs11/{idx}",
+                name=Path(mod).name or f"pkcs11-module-{idx}",
+                category="pkcs11",
+                asset_type="protocol",
+                protocol_type="other",
+                properties=(("pkcs11:module_path", mod),),
+            )
+        )
+    return out
+
+
+def _canonical_openssl_assets(r: Report) -> list[CryptoAsset]:
     osinfo = r.openssl or {}
     if not osinfo.get("available"):
         return []
-    out: list[dict[str, Any]] = []
+    out: list[CryptoAsset] = []
     version = osinfo.get("version") or "unknown"
     src = f"openssl@{version}"
     for kem in osinfo.get("kem_algorithms") or []:
         out.append(
-            _cbom_pqc_algorithm_asset(
+            _pqc_algorithm_asset(
                 f"openssl/kem/{kem}",
                 kem,
+                "openssl_kem",
                 "kem",
                 src,
             )
         )
     for sig in osinfo.get("sig_algorithms") or []:
         out.append(
-            _cbom_pqc_algorithm_asset(
+            _pqc_algorithm_asset(
                 f"openssl/sig/{sig}",
                 sig,
+                "openssl_sig",
                 "signature",
                 src,
             )
@@ -4068,93 +4100,74 @@ def _cbom_openssl_assets(r: Report) -> list[dict[str, Any]]:
     tls_groups = osinfo.get("tls_groups") or {}
     for grp in tls_groups.get("hybrid") or []:
         out.append(
-            _cbom_asset(
-                bom_ref=f"openssl/tls-hybrid/{grp}",
+            CryptoAsset(
+                key=f"openssl/tls-hybrid/{grp}",
                 name=grp,
-                crypto_props={
-                    "assetType": "algorithm",
-                    "algorithmProperties": {
-                        "primitive": "combiner",
-                        "executionEnvironment": "software-plain-ram",
-                    },
-                },
-                extra_props=[
-                    {"name": "source", "value": src},
-                    {"name": "tls:role", "value": "hybrid-group"},
-                ],
+                category="openssl_tls_hybrid",
+                asset_type="algorithm",
+                primitive="combiner",
+                execution_environment="software-plain-ram",
+                source=src,
+                properties=(("tls:role", "hybrid-group"),),
             )
         )
     for grp in tls_groups.get("pure_pqc") or []:
         out.append(
-            _cbom_asset(
-                bom_ref=f"openssl/tls-pure-pqc/{grp}",
+            CryptoAsset(
+                key=f"openssl/tls-pure-pqc/{grp}",
                 name=grp,
-                crypto_props={
-                    "assetType": "algorithm",
-                    "algorithmProperties": {
-                        "primitive": "kem",
-                        "executionEnvironment": "software-plain-ram",
-                    },
-                },
-                extra_props=[
-                    {"name": "source", "value": src},
-                    {"name": "tls:role", "value": "pure-pqc-group"},
-                ],
+                category="openssl_tls_pqc",
+                asset_type="algorithm",
+                primitive="kem",
+                execution_environment="software-plain-ram",
+                source=src,
+                properties=(("tls:role", "pure-pqc-group"),),
             )
         )
     return out
 
 
-def _cbom_ssh_assets(r: Report) -> list[dict[str, Any]]:
+def _canonical_ssh_assets(r: Report) -> list[CryptoAsset]:
     """SSH KEX algorithms surface as key-agreement assets.  We only emit
     the PQC subset detected by `ssh -Q kex` — the classical kex set is
     out of scope for a PQC inventory."""
     ssh_info = r.ssh_pqc or {}
     if not ssh_info.get("available"):
         return []
-    out: list[dict[str, Any]] = []
+    out: list[CryptoAsset] = []
     version = ssh_info.get("version") or "unknown"
+    src = f"openssh@{version}"
     kex_groups = ssh_info.get("kex_groups") or {}
     for kex in kex_groups.get("hybrid") or []:
         out.append(
-            _cbom_asset(
-                bom_ref=f"ssh/kex/hybrid/{kex}",
+            CryptoAsset(
+                key=f"ssh/kex/hybrid/{kex}",
                 name=kex,
-                crypto_props={
-                    "assetType": "algorithm",
-                    "algorithmProperties": {
-                        "primitive": "key-agree",
-                        "executionEnvironment": "software-plain-ram",
-                    },
-                },
-                extra_props=[
-                    {"name": "source", "value": f"openssh@{version}"},
-                    {"name": "ssh:role", "value": "hybrid-kex"},
-                ],
+                category="ssh_kex_hybrid",
+                asset_type="algorithm",
+                primitive="key-agree",
+                execution_environment="software-plain-ram",
+                source=src,
+                properties=(("ssh:role", "hybrid-kex"),),
             )
         )
     for kex in kex_groups.get("pure_pqc") or []:
         out.append(
-            _cbom_asset(
-                bom_ref=f"ssh/kex/pure-pqc/{kex}",
+            CryptoAsset(
+                key=f"ssh/kex/pure-pqc/{kex}",
                 name=kex,
-                crypto_props={
-                    "assetType": "algorithm",
-                    "algorithmProperties": {
-                        "primitive": "kem",
-                        "executionEnvironment": "software-plain-ram",
-                    },
-                },
-                extra_props=[
-                    {"name": "source", "value": f"openssh@{version}"},
-                    {"name": "ssh:role", "value": "pure-pqc-kex"},
-                ],
+                category="ssh_kex_pqc",
+                asset_type="algorithm",
+                primitive="kem",
+                execution_environment="software-plain-ram",
+                source=src,
+                properties=(("ssh:role", "pure-pqc-kex"),),
             )
         )
     return out
 
 
-def _cbom_ipsec_assets(r: Report) -> list[dict[str, Any]]:
+def _canonical_ipsec_assets(r: Report) -> list[CryptoAsset]:
     """IPsec stacks expose PQC support as a single boolean today; emit
     one protocol asset describing the implementation found and whether
     it advertises any PQC KE.  When a future strongSwan release ships
@@ -4163,81 +4176,30 @@ def _cbom_ipsec_assets(r: Report) -> list[dict[str, Any]]:
     if not ipsec.get("available"):
         return []
     impl = str(ipsec.get("implementation") or "ipsec")
-    extra = [{"name": "ipsec:implementation", "value": impl}]
+    props: list[tuple[str, str]] = [("ipsec:implementation", impl)]
     if ipsec.get("evidence"):
-        extra.append({"name": "ipsec:evidence", "value": str(ipsec["evidence"])})
+        props.append(("ipsec:evidence", str(ipsec["evidence"])))
     if ipsec.get("version"):
-        extra.append({"name": "ipsec:version", "value": str(ipsec["version"])})
-    extra.append(
-        {
-            "name": "ipsec:pqc_advertised",
-            "value": "true" if ipsec.get("pqc") else "false",
-        }
+        props.append(("ipsec:version", str(ipsec["version"])))
+    props.append(
+        (
+            "ipsec:pqc_advertised",
+            "true" if ipsec.get("pqc") else "false",
+        )
     )
     return [
-        _cbom_asset(
-            bom_ref=f"ipsec/{impl}",
+        CryptoAsset(
+            key=f"ipsec/{impl}",
             name=f"IPsec ({impl})",
-            crypto_props={
-                "assetType": "protocol",
-                "protocolProperties": {"type": "ipsec"},
-            },
-            extra_props=extra,
+            category="ipsec",
+            asset_type="protocol",
+            protocol_type="ipsec",
+            properties=tuple(props),
         )
     ]
 
 
-def _cbom_pkcs11_assets(r: Report) -> list[dict[str, Any]]:
-    """PKCS#11 is a cryptographic-token API; each loadable module is
-    emitted as a protocol asset with the module path captured in a
-    property so an aggregator can deduplicate identical modules across
-    a fleet."""
-    out: list[dict[str, Any]] = []
-    for idx, mod in enumerate(r.pkcs11_modules or []):
-        out.append(
-            _cbom_asset(
-                bom_ref=f"pkcs11/{idx}",
-                name=Path(mod).name or f"pkcs11-module-{idx}",
-                crypto_props={
-                    "assetType": "protocol",
-                    "protocolProperties": {"type": "other"},
-                },
-                extra_props=[
-                    {"name": "pkcs11:module_path", "value": mod},
-                ],
-            )
-        )
-    return out
-
-
-def _cbom_tpm_assets(r: Report) -> list[dict[str, Any]]:
-    tpm = r.tpm_pqc or {}
-    if not tpm.get("present"):
-        return []
-    return [
-        _cbom_asset(
-            bom_ref="tpm/pqc",
-            name="TPM PQC capability",
-            crypto_props={
-                "assetType": "algorithm",
-                "algorithmProperties": {
-                    "primitive": "other",
-                    "executionEnvironment": "hardware",
-                    "implementationPlatform": _cbom_platform(r.arch),
-                },
-            },
-            extra_props=[
-                {
-                    "name": "tpm:pqc_advertised",
-                    "value": "true" if tpm.get("pqc_advertised") else "false",
-                },
-                {"name": "tpm:note", "value": str(tpm.get("note", ""))},
-            ],
-        )
-    ]
-
-
-def _cbom_trust_store_assets(r: Report) -> list[dict[str, Any]]:
+def _canonical_trust_store_assets(r: Report) -> list[CryptoAsset]:
     """Trust-store scan is summary-only (counts by category) — there is
     no per-cert detail in the Report, so we emit a single related-crypto-
     material asset whose properties carry the totals.  When a richer
@@ -4246,49 +4208,116 @@ def _cbom_trust_store_assets(r: Report) -> list[dict[str, Any]]:
     ts = r.trust_store or {}
     if not ts.get("available"):
         return []
-    extra = [
-        {"name": "trust_store:total_certs", "value": str(ts.get("total_certs", 0))},
-        {"name": "trust_store:pqc_certs", "value": str(ts.get("pqc_certs", 0))},
-        {"name": "trust_store:hybrid_certs", "value": str(ts.get("hybrid_certs", 0))},
+    props: list[tuple[str, str]] = [
+        ("trust_store:total_certs", str(ts.get("total_certs", 0))),
+        ("trust_store:pqc_certs", str(ts.get("pqc_certs", 0))),
+        ("trust_store:hybrid_certs", str(ts.get("hybrid_certs", 0))),
     ]
     cats = ts.get("cert_categories") or {}
     for cat in ("classical", "hybrid_composite", "pure_pqc"):
-        extra.append(
-            {
-                "name": f"trust_store:cert_categories:{cat}",
-                "value": str(cats.get(cat, 0)),
-            }
+        props.append(
+            (
+                f"trust_store:cert_categories:{cat}",
+                str(cats.get(cat, 0)),
+            )
         )
     for d in ts.get("scanned_dirs") or []:
-        extra.append({"name": "trust_store:scanned_dir", "value": d})
+        props.append(("trust_store:scanned_dir", d))
     return [
-        _cbom_asset(
-            bom_ref="trust-store/summary",
+        CryptoAsset(
+            key="trust-store/summary",
             name="Trust store certificate inventory",
-            crypto_props={
-                "assetType": "related-crypto-material",
-                "relatedCryptoMaterialProperties": {"type": "other"},
-            },
-            extra_props=extra,
+            category="trust_store",
+            asset_type="related-crypto-material",
+            related_material_type="other",
+            properties=tuple(props),
         )
     ]
+
+
+def canonical_assets(r: Report) -> list[CryptoAsset]:
+    """Walk the Report and return the canonical CryptoAsset list.
+
+    Order is deterministic so that downstream diffs across runs on the
+    same host stay stable: ISA → accelerators → TPM → PKCS#11 →
+    OpenSSL → SSH → IPsec → trust-store summary."""
+    out: list[CryptoAsset] = []
+    out.extend(_canonical_isa_assets(r))
+    out.extend(_canonical_accelerator_assets(r))
+    out.extend(_canonical_tpm_assets(r))
+    out.extend(_canonical_pkcs11_assets(r))
+    out.extend(_canonical_openssl_assets(r))
+    out.extend(_canonical_ssh_assets(r))
+    out.extend(_canonical_ipsec_assets(r))
+    out.extend(_canonical_trust_store_assets(r))
+    return out
+
+
+# CycloneDX 1.6 CBOM rendering ----------------------------------------------
+#
+# A CBOM (Cryptographic Bill of Materials) is a CycloneDX BOM whose
+# `components` are populated with `cryptographic-asset` entries.  NIST IR
+# 8547 references CycloneDX 1.6 as the standard for cryptographic inventory
+# exchange, so emitting this shape lets downstream PQC-migration tooling
+# ingest pqc-readiness output without writing a bespoke translator.
+
+# Provenance tag stamped onto every emitted CBOM asset so downstream
+# aggregators can tell which tool detected the entry.
+def _cbom_provenance() -> list[dict[str, str]]:
+    return [{"name": "detectedBy", "value": f"pqc-readiness@{SCRIPT_VERSION}"}]
+
+
+def _cbom_crypto_properties(asset: CryptoAsset) -> dict[str, Any]:
+    """Project a canonical asset's crypto properties into the CycloneDX
+    1.6 cryptographic-asset shape."""
+    if asset.asset_type == "algorithm":
+        algo: dict[str, Any] = {"primitive": asset.primitive or "other"}
+        if asset.execution_environment:
+            algo["executionEnvironment"] = asset.execution_environment
+        if asset.implementation_platform:
+            algo["implementationPlatform"] = asset.implementation_platform
+        if asset.parameter_set:
+            algo["parameterSetIdentifier"] = asset.parameter_set
+        if asset.nist_category is not None:
+            algo["nistQuantumSecurityLevel"] = asset.nist_category
+        return {"assetType": "algorithm", "algorithmProperties": algo}
+    if asset.asset_type == "protocol":
+        return {
+            "assetType": "protocol",
+            "protocolProperties": {"type": asset.protocol_type or "other"},
+        }
+    if asset.asset_type == "related-crypto-material":
+        return {
+            "assetType": "related-crypto-material",
+            "relatedCryptoMaterialProperties": {
+                "type": asset.related_material_type or "other"
+            },
+        }
+    raise ValueError(f"unsupported CryptoAsset.asset_type: {asset.asset_type!r}")
+
+
+def _cbom_component(asset: CryptoAsset) -> dict[str, Any]:
+    """Project a canonical asset into a CycloneDX 1.6 cryptographic-asset
+    component.  Every emitted asset carries the `detectedBy` provenance
+    tag plus any free-form (k, v) properties from the canonical record."""
+    props = _cbom_provenance()
+    if asset.source:
+        props.append({"name": "source", "value": asset.source})
+    for k, v in asset.properties:
+        props.append({"name": k, "value": v})
+    return {
+        "type": "cryptographic-asset",
+        "bom-ref": asset.key,
+        "name": asset.name,
+        "cryptoProperties": _cbom_crypto_properties(asset),
+        "properties": props,
+    }
 
 
 def render_cbom(r: Report) -> str:
     """Render the report as a CycloneDX 1.6 CBOM (JSON).  The output is
     schema-conformant — see tests/test_cbom.py for the schema check."""
-    components: list[dict[str, Any]] = []
-    for builder in (
-        _cbom_isa_assets,
-        _cbom_accelerator_assets,
-        _cbom_tpm_assets,
-        _cbom_pkcs11_assets,
-        _cbom_openssl_assets,
-        _cbom_ssh_assets,
-        _cbom_ipsec_assets,
-        _cbom_trust_store_assets,
-    ):
-        components.extend(builder(r))
+    components = [_cbom_component(a) for a in canonical_assets(r)]
 
     timestamp = r.generated_at or datetime.now(timezone.utc).isoformat(
         timespec="seconds"

--- a/pqc_readiness.py
+++ b/pqc_readiness.py
@@ -17,6 +17,7 @@ Usage:
     pqc-readiness                           human-readable report
     pqc-readiness --json                    machine-readable (stable schema)
     pqc-readiness --cbom                    CycloneDX 1.6 CBOM JSON (NIST IR 8547)
+    pqc-readiness --spdx                    SPDX 3.0 JSON-LD (Security profile)
     pqc-readiness --sarif                   SARIF 2.1.0 findings (OASIS)
     pqc-readiness --markdown                markdown report (for tickets)
     pqc-readiness --bench                   run PQC + classical microbench
@@ -4712,6 +4713,369 @@ def render_sarif(r: Report) -> str:
     return json.dumps(log, indent=2)
 
 
+# ---------------------------------------------------------------------------
+# SPDX 3.0 JSON-LD output (--spdx)
+# ---------------------------------------------------------------------------
+# SPDX 3.0 added a Security profile that overlaps with CBOM use cases.
+# Some procurement contexts (notably US federal) standardise on SPDX
+# rather than CycloneDX, so emitting both broadens compatibility without
+# forcing customers to convert formats.
+#
+# Same source data as --cbom — both renderers project from the
+# canonical_assets() pipeline above.  Findings (the same set of rule
+# predicates that drive --sarif) are emitted here as
+# security_Vulnerability elements with VEX "affects" relationships
+# linking each finding to the host package.
+#
+# Validation: SPDX 3.0.1 does not publish a JSON Schema; the canonical
+# validation surface is the OWL/SHACL ontology.  tests/test_spdx.py
+# bundles the official JSON-LD context file and runs a structural
+# validator that mirrors the spec's required-shape constraints
+# (top-level @context + @graph, every Element carries creationInfo,
+# every type/property is a known term in the SPDX 3.0.1 context).
+#
+# Refs:
+#   https://spdx.github.io/spdx-spec/v3.0.1/  (SPDX 3.0.1 spec)
+#   https://spdx.org/rdf/3.0.1/spdx-context.jsonld  (canonical context)
+
+SPDX_VERSION = "3.0.1"
+SPDX_CONTEXT_URL = "https://spdx.org/rdf/3.0.1/spdx-context.jsonld"
+SPDX_DATA_LICENSE = "https://spdx.org/licenses/CC0-1.0"
+
+# URN namespace prefix for spdxIds emitted by this tool.  URNs are valid
+# IRIs and avoid implying a resolvable HTTP endpoint.
+SPDX_URN_PREFIX = "urn:pqc-readiness"
+
+
+def _spdx_safe(s: str) -> str:
+    """Sanitise a string for inclusion in a URN segment.  SPDX 3.0
+    spdxIds are IRIs; we conservatively keep alphanumerics plus
+    [.-_] and replace runs of anything else with a single dash."""
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", s).strip("-")
+    return cleaned or "unknown"
+
+
+def _spdx_software_purpose(asset: CryptoAsset) -> str:
+    """Map a canonical asset onto the SPDX 3.0 SoftwarePurpose enum.
+
+    The enum is fixed (see /Software/SoftwarePurpose) so we collapse
+    crypto-asset categories to the closest enum entry: hardware-execution
+    assets surface as `device`, software algorithms / protocols as
+    `library`, and the trust-store summary as `data`."""
+    if asset.execution_environment == "hardware":
+        return "device"
+    if asset.asset_type == "related-crypto-material":
+        return "data"
+    return "library"
+
+
+def _spdx_creation_info(creator_id: str) -> dict[str, Any]:
+    """SPDX 3.0 inlines CreationInfo on every Element.  Every element in
+    a single document shares the same created-time + creator agent."""
+    return {
+        "type": "CreationInfo",
+        "specVersion": SPDX_VERSION,
+        "created": _CURRENT_RUN_TIME[0],
+        "createdBy": [creator_id],
+    }
+
+
+# Module-level slot so _spdx_creation_info renders a stable timestamp
+# across all elements in one document; render_spdx() updates it once.
+_CURRENT_RUN_TIME: list[str] = ["1970-01-01T00:00:00Z"]
+
+
+def _spdx_element_base(
+    spdx_id: str,
+    type_name: str,
+    name: str,
+    creator_id: str,
+) -> dict[str, Any]:
+    return {
+        "type": type_name,
+        "spdxId": spdx_id,
+        "creationInfo": _spdx_creation_info(creator_id),
+        "name": name,
+    }
+
+
+def _spdx_creator_agent(spdx_id: str) -> dict[str, Any]:
+    """The pqc-readiness tool itself, modelled as a SoftwareAgent.
+
+    SoftwareAgent is the SPDX 3.0 class for software acting on a system.
+    The agent is its own creator (self-reference is permitted by the
+    spec and is the standard bootstrap pattern) so the document does
+    not require an external Agent registry."""
+    return {
+        "type": "SoftwareAgent",
+        "spdxId": spdx_id,
+        "creationInfo": _spdx_creation_info(spdx_id),
+        "name": "pqc-readiness",
+        "description": (
+            "Open-source PQC readiness scanner — see "
+            "https://github.com/aclater/pqc-readiness"
+        ),
+    }
+
+
+def _spdx_host_package(
+    spdx_id: str,
+    creator_id: str,
+    r: Report,
+) -> dict[str, Any]:
+    """The scanned host as a software_Package.
+
+    The host is the package whose cryptographic inventory this document
+    describes.  Findings (Vulnerability elements) attach to it via VEX
+    relationships."""
+    pkg = _spdx_element_base(
+        spdx_id,
+        "software_Package",
+        r.hostname or "unknown-host",
+        creator_id,
+    )
+    summary_bits: list[str] = []
+    if r.os:
+        summary_bits.append(r.os)
+    if r.arch:
+        summary_bits.append(r.arch)
+    if summary_bits:
+        pkg["summary"] = " / ".join(summary_bits)
+    pkg["software_primaryPurpose"] = "platform"
+    if r.cpu_model:
+        pkg["description"] = f"CPU: {r.cpu_model}"
+    return pkg
+
+
+def _spdx_asset_package(
+    asset: CryptoAsset,
+    namespace: str,
+    creator_id: str,
+) -> dict[str, Any]:
+    """Project a canonical CryptoAsset into an SPDX 3.0 software_Package.
+
+    SPDX 3.0 doesn't ship a native cryptographic-asset element type, so
+    we model each asset as a software_Package with `software_primaryPurpose`
+    set per the asset's execution environment.  Crypto metadata that has
+    no native SPDX field (primitive, parameter set, NIST category, source,
+    free-form properties) goes into `description` as a stable, parseable
+    `key=value` block — the same data CBOM emits as `properties`."""
+    spdx_id = f"{namespace}:asset:{_spdx_safe(asset.key)}"
+    elem = _spdx_element_base(
+        spdx_id,
+        "software_Package",
+        asset.name,
+        creator_id,
+    )
+    elem["summary"] = f"Cryptographic asset (category={asset.category})"
+    elem["software_primaryPurpose"] = _spdx_software_purpose(asset)
+
+    desc_lines: list[str] = [f"category={asset.category}"]
+    desc_lines.append(f"assetType={asset.asset_type}")
+    if asset.primitive:
+        desc_lines.append(f"primitive={asset.primitive}")
+    if asset.execution_environment:
+        desc_lines.append(f"executionEnvironment={asset.execution_environment}")
+    if asset.implementation_platform:
+        desc_lines.append(f"implementationPlatform={asset.implementation_platform}")
+    if asset.protocol_type:
+        desc_lines.append(f"protocolType={asset.protocol_type}")
+    if asset.related_material_type:
+        desc_lines.append(f"relatedMaterialType={asset.related_material_type}")
+    if asset.source:
+        desc_lines.append(f"source={asset.source}")
+    for k, v in asset.properties:
+        desc_lines.append(f"{k}={v}")
+    elem["description"] = "\n".join(desc_lines)
+
+    if asset.parameter_set:
+        elem["software_packageVersion"] = asset.parameter_set
+    if asset.nist_category is not None:
+        elem["externalIdentifier"] = [
+            {
+                "type": "ExternalIdentifier",
+                "externalIdentifierType": "other",
+                "identifier": f"nist-pqc-category-{asset.nist_category}",
+            }
+        ]
+    return elem
+
+
+# Help-URL base for security_Vulnerability elements emitted to SPDX —
+# reuses the SARIF rule docs so each finding type has one canonical
+# explanation page across formats.
+SPDX_FINDING_HELP_BASE = SARIF_HELP_BASE
+SPDX_FINDING_LEVEL_TO_NOTE = {
+    "error": "severity: error",
+    "warning": "severity: warning",
+    "note": "severity: note",
+}
+
+
+def _spdx_vulnerability(
+    finding: Finding,
+    rule_spec: RuleSpec,
+    namespace: str,
+    creator_id: str,
+    idx: int,
+) -> dict[str, Any]:
+    """Each Finding becomes a security_Vulnerability whose summary is
+    the rule's short description and whose full description is the
+    rule body plus the rule-fired message.
+
+    Keeping the SARIF rule_id as the externalIdentifier lets tooling
+    correlate the same finding across SARIF and SPDX outputs."""
+    spdx_id = f"{namespace}:finding:{idx:04d}:{_spdx_safe(rule_spec.id)}"
+    elem = _spdx_element_base(
+        spdx_id,
+        "security_Vulnerability",
+        rule_spec.id,
+        creator_id,
+    )
+    elem["summary"] = rule_spec.short_description
+    elem["description"] = (
+        f"{rule_spec.full_description}\n\nDetected: {finding.message}"
+    )
+    elem["comment"] = SPDX_FINDING_LEVEL_TO_NOTE.get(
+        finding.level, f"severity: {finding.level}"
+    )
+    elem["security_publishedTime"] = _CURRENT_RUN_TIME[0]
+    elem["externalIdentifier"] = [
+        {
+            "type": "ExternalIdentifier",
+            "externalIdentifierType": "other",
+            "identifier": rule_spec.id,
+        }
+    ]
+    elem["externalRef"] = [
+        {
+            "type": "ExternalRef",
+            "externalRefType": "securityAdvisory",
+            "locator": [rule_spec.help_uri],
+        }
+    ]
+    return elem
+
+
+def _spdx_vex_affects(
+    vuln_id: str,
+    target_id: str,
+    namespace: str,
+    creator_id: str,
+    idx: int,
+    action_statement: str,
+) -> dict[str, Any]:
+    """Link a security_Vulnerability to the host package via a VEX
+    `affects` relationship.
+
+    VexAffectedVulnAssessmentRelationship is the SPDX 3.0 way to declare
+    "vulnerability V affects element E" — in this document E is always
+    the scanned host package."""
+    return {
+        "type": "security_VexAffectedVulnAssessmentRelationship",
+        "spdxId": f"{namespace}:vex:{idx:04d}",
+        "creationInfo": _spdx_creation_info(creator_id),
+        "relationshipType": "affects",
+        "from": vuln_id,
+        "to": [target_id],
+        "security_assessedElement": target_id,
+        "security_actionStatement": action_statement,
+        "security_publishedTime": _CURRENT_RUN_TIME[0],
+    }
+
+
+def render_spdx(r: Report) -> str:
+    """Render the report as an SPDX 3.0 JSON-LD document.
+
+    The document profileConformance includes core, software, and
+    security: cryptographic assets are software_Package elements and
+    findings are security_Vulnerability elements with VEX `affects`
+    relationships to the scanned host."""
+    timestamp = r.generated_at or datetime.now(timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+    # The official spec wants an `xsd:dateTimeStamp`; that means a
+    # mandatory timezone designator.  Report.generated_at carries
+    # +00:00; SPDX examples use the trailing-Z form.  We accept either.
+    _CURRENT_RUN_TIME[0] = timestamp
+
+    host_safe = _spdx_safe(r.hostname or "unknown-host")
+    namespace = f"{SPDX_URN_PREFIX}:{host_safe}"
+    creator_id = f"{SPDX_URN_PREFIX}:tool:{_spdx_safe(SCRIPT_VERSION)}"
+    host_id = f"{namespace}:host"
+    sbom_id = f"{namespace}:sbom"
+    doc_id = f"{namespace}:document:{uuid.uuid4()}"
+
+    creator = _spdx_creator_agent(creator_id)
+    host_pkg = _spdx_host_package(host_id, creator_id, r)
+    asset_pkgs = [
+        _spdx_asset_package(a, namespace, creator_id) for a in canonical_assets(r)
+    ]
+
+    findings = build_findings(r)
+    rule_specs_by_id = {s.id: s for s in RULE_SPECS}
+    vulns: list[dict[str, Any]] = []
+    vex_rels: list[dict[str, Any]] = []
+    for idx, f in enumerate(findings):
+        spec = rule_specs_by_id.get(f.rule_id)
+        if spec is None:
+            continue
+        vuln = _spdx_vulnerability(f, spec, namespace, creator_id, idx)
+        vulns.append(vuln)
+        vex_rels.append(
+            _spdx_vex_affects(
+                vuln["spdxId"],
+                host_id,
+                namespace,
+                creator_id,
+                idx,
+                action_statement=f.message,
+            )
+        )
+
+    member_ids: list[str] = (
+        [host_id]
+        + [pkg["spdxId"] for pkg in asset_pkgs]
+        + [v["spdxId"] for v in vulns]
+        + [rel["spdxId"] for rel in vex_rels]
+    )
+
+    sbom: dict[str, Any] = {
+        "type": "software_Sbom",
+        "spdxId": sbom_id,
+        "creationInfo": _spdx_creation_info(creator_id),
+        "name": f"pqc-readiness inventory for {r.hostname or 'unknown-host'}",
+        "profileConformance": ["core", "software", "security"],
+        "rootElement": [host_id],
+        "element": member_ids,
+        "software_sbomType": ["analyzed"],
+    }
+
+    document: dict[str, Any] = {
+        "type": "SpdxDocument",
+        "spdxId": doc_id,
+        "creationInfo": _spdx_creation_info(creator_id),
+        "name": f"pqc-readiness {SCRIPT_VERSION} report",
+        "profileConformance": ["core", "software", "security"],
+        "dataLicense": SPDX_DATA_LICENSE,
+        "rootElement": [sbom_id],
+        "element": [sbom_id, *member_ids, creator_id],
+    }
+
+    graph: list[dict[str, Any]] = [
+        creator,
+        document,
+        sbom,
+        host_pkg,
+        *asset_pkgs,
+        *vulns,
+        *vex_rels,
+    ]
+
+    out = {"@context": SPDX_CONTEXT_URL, "@graph": graph}
+    return json.dumps(out, indent=2)
+
+
 def render_text(r: Report) -> str:
     L: list[str] = []
     bar = "=" * 76
@@ -5143,6 +5507,11 @@ def main() -> int:
         help="emit CycloneDX 1.6 CBOM JSON (NIST IR 8547)",
     )
     ap.add_argument(
+        "--spdx",
+        action="store_true",
+        help="emit SPDX 3.0 JSON-LD (Security profile) for SPDX-native pipelines",
+    )
+    ap.add_argument(
         "--sarif",
         action="store_true",
         help="emit SARIF 2.1.0 findings (OASIS) for security pipelines",
@@ -5252,6 +5621,7 @@ def main() -> int:
         and not args.json
         and not args.markdown
         and not args.cbom
+        and not args.spdx
         and not args.sarif
     )
 
@@ -5403,6 +5773,8 @@ def main() -> int:
         print(json.dumps(asdict(r), indent=2))
     elif args.cbom:
         print(render_cbom(r))
+    elif args.spdx:
+        print(render_spdx(r))
     elif args.sarif:
         print(render_sarif(r))
     elif args.markdown:

--- a/tests/fixtures/spdx/spdx-3.0.1-context.jsonld
+++ b/tests/fixtures/spdx/spdx-3.0.1-context.jsonld
@@ -1,0 +1,816 @@
+{
+  "@context": {
+    "Agent": "https://spdx.org/rdf/3.0.1/terms/Core/Agent",
+    "Annotation": "https://spdx.org/rdf/3.0.1/terms/Core/Annotation",
+    "AnnotationType": "https://spdx.org/rdf/3.0.1/terms/Core/AnnotationType",
+    "Artifact": "https://spdx.org/rdf/3.0.1/terms/Core/Artifact",
+    "Bom": "https://spdx.org/rdf/3.0.1/terms/Core/Bom",
+    "Bundle": "https://spdx.org/rdf/3.0.1/terms/Core/Bundle",
+    "CreationInfo": "https://spdx.org/rdf/3.0.1/terms/Core/CreationInfo",
+    "DictionaryEntry": "https://spdx.org/rdf/3.0.1/terms/Core/DictionaryEntry",
+    "Element": "https://spdx.org/rdf/3.0.1/terms/Core/Element",
+    "ElementCollection": "https://spdx.org/rdf/3.0.1/terms/Core/ElementCollection",
+    "ExternalIdentifier": "https://spdx.org/rdf/3.0.1/terms/Core/ExternalIdentifier",
+    "ExternalIdentifierType": "https://spdx.org/rdf/3.0.1/terms/Core/ExternalIdentifierType",
+    "ExternalMap": "https://spdx.org/rdf/3.0.1/terms/Core/ExternalMap",
+    "ExternalRef": "https://spdx.org/rdf/3.0.1/terms/Core/ExternalRef",
+    "ExternalRefType": "https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType",
+    "Hash": "https://spdx.org/rdf/3.0.1/terms/Core/Hash",
+    "HashAlgorithm": "https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm",
+    "IndividualElement": "https://spdx.org/rdf/3.0.1/terms/Core/IndividualElement",
+    "IntegrityMethod": "https://spdx.org/rdf/3.0.1/terms/Core/IntegrityMethod",
+    "LifecycleScopeType": "https://spdx.org/rdf/3.0.1/terms/Core/LifecycleScopeType",
+    "LifecycleScopedRelationship": "https://spdx.org/rdf/3.0.1/terms/Core/LifecycleScopedRelationship",
+    "NamespaceMap": "https://spdx.org/rdf/3.0.1/terms/Core/NamespaceMap",
+    "NoAssertionElement": "https://spdx.org/rdf/3.0.1/terms/Core/NoAssertionElement",
+    "NoneElement": "https://spdx.org/rdf/3.0.1/terms/Core/NoneElement",
+    "Organization": "https://spdx.org/rdf/3.0.1/terms/Core/Organization",
+    "PackageVerificationCode": "https://spdx.org/rdf/3.0.1/terms/Core/PackageVerificationCode",
+    "Person": "https://spdx.org/rdf/3.0.1/terms/Core/Person",
+    "PositiveIntegerRange": "https://spdx.org/rdf/3.0.1/terms/Core/PositiveIntegerRange",
+    "PresenceType": "https://spdx.org/rdf/3.0.1/terms/Core/PresenceType",
+    "ProfileIdentifierType": "https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType",
+    "Relationship": "https://spdx.org/rdf/3.0.1/terms/Core/Relationship",
+    "RelationshipCompleteness": "https://spdx.org/rdf/3.0.1/terms/Core/RelationshipCompleteness",
+    "RelationshipType": "https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType",
+    "SoftwareAgent": "https://spdx.org/rdf/3.0.1/terms/Core/SoftwareAgent",
+    "SpdxDocument": "https://spdx.org/rdf/3.0.1/terms/Core/SpdxDocument",
+    "SpdxOrganization": "https://spdx.org/rdf/3.0.1/terms/Core/SpdxOrganization",
+    "SupportType": "https://spdx.org/rdf/3.0.1/terms/Core/SupportType",
+    "Tool": "https://spdx.org/rdf/3.0.1/terms/Core/Tool",
+    "ai_AIPackage": "https://spdx.org/rdf/3.0.1/terms/AI/AIPackage",
+    "ai_EnergyConsumption": "https://spdx.org/rdf/3.0.1/terms/AI/EnergyConsumption",
+    "ai_EnergyConsumptionDescription": "https://spdx.org/rdf/3.0.1/terms/AI/EnergyConsumptionDescription",
+    "ai_EnergyUnitType": "https://spdx.org/rdf/3.0.1/terms/AI/EnergyUnitType",
+    "ai_SafetyRiskAssessmentType": "https://spdx.org/rdf/3.0.1/terms/AI/SafetyRiskAssessmentType",
+    "ai_autonomyType": {
+      "@context": {
+        "@vocab": "https://spdx.org/rdf/3.0.1/terms/Core/PresenceType/"
+      },
+      "@id": "https://spdx.org/rdf/3.0.1/terms/AI/autonomyType",
+      "@type": "@vocab"
+    },
+    "ai_domain": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/AI/domain",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "ai_energyConsumption": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/AI/energyConsumption",
+      "@type": "@vocab"
+    },
+    "ai_energyQuantity": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/AI/energyQuantity",
+      "@type": "http://www.w3.org/2001/XMLSchema#decimal"
+    },
+    "ai_energyUnit": {
+      "@context": {
+        "@vocab": "https://spdx.org/rdf/3.0.1/terms/AI/EnergyUnitType/"
+      },
+      "@id": "https://spdx.org/rdf/3.0.1/terms/AI/energyUnit",
+      "@type": "@vocab"
+    },
+    "ai_finetuningEnergyConsumption": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/AI/finetuningEnergyConsumption",
+      "@type": "@vocab"
+    },
+    "ai_hyperparameter": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/AI/hyperparameter",
+      "@type": "@vocab"
+    },
+    "ai_inferenceEnergyConsumption": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/AI/inferenceEnergyConsumption",
+      "@type": "@vocab"
+    },
+    "ai_informationAboutApplication": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/AI/informationAboutApplication",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "ai_informationAboutTraining": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/AI/informationAboutTraining",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "ai_limitation": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/AI/limitation",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "ai_metric": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/AI/metric",
+      "@type": "@vocab"
+    },
+    "ai_metricDecisionThreshold": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/AI/metricDecisionThreshold",
+      "@type": "@vocab"
+    },
+    "ai_modelDataPreprocessing": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/AI/modelDataPreprocessing",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "ai_modelExplainability": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/AI/modelExplainability",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "ai_safetyRiskAssessment": {
+      "@context": {
+        "@vocab": "https://spdx.org/rdf/3.0.1/terms/AI/SafetyRiskAssessmentType/"
+      },
+      "@id": "https://spdx.org/rdf/3.0.1/terms/AI/safetyRiskAssessment",
+      "@type": "@vocab"
+    },
+    "ai_standardCompliance": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/AI/standardCompliance",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "ai_trainingEnergyConsumption": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/AI/trainingEnergyConsumption",
+      "@type": "@vocab"
+    },
+    "ai_typeOfModel": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/AI/typeOfModel",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "ai_useSensitivePersonalInformation": {
+      "@context": {
+        "@vocab": "https://spdx.org/rdf/3.0.1/terms/Core/PresenceType/"
+      },
+      "@id": "https://spdx.org/rdf/3.0.1/terms/AI/useSensitivePersonalInformation",
+      "@type": "@vocab"
+    },
+    "algorithm": {
+      "@context": {
+        "@vocab": "https://spdx.org/rdf/3.0.1/terms/Core/HashAlgorithm/"
+      },
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/algorithm",
+      "@type": "@vocab"
+    },
+    "annotationType": {
+      "@context": {
+        "@vocab": "https://spdx.org/rdf/3.0.1/terms/Core/AnnotationType/"
+      },
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/annotationType",
+      "@type": "@vocab"
+    },
+    "beginIntegerRange": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/beginIntegerRange",
+      "@type": "http://www.w3.org/2001/XMLSchema#positiveInteger"
+    },
+    "build_Build": "https://spdx.org/rdf/3.0.1/terms/Build/Build",
+    "build_buildEndTime": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Build/buildEndTime",
+      "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
+    },
+    "build_buildId": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Build/buildId",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "build_buildStartTime": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Build/buildStartTime",
+      "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
+    },
+    "build_buildType": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Build/buildType",
+      "@type": "http://www.w3.org/2001/XMLSchema#anyURI"
+    },
+    "build_configSourceDigest": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Build/configSourceDigest",
+      "@type": "@vocab"
+    },
+    "build_configSourceEntrypoint": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Build/configSourceEntrypoint",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "build_configSourceUri": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Build/configSourceUri",
+      "@type": "http://www.w3.org/2001/XMLSchema#anyURI"
+    },
+    "build_environment": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Build/environment",
+      "@type": "@vocab"
+    },
+    "build_parameter": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Build/parameter",
+      "@type": "@vocab"
+    },
+    "builtTime": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/builtTime",
+      "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
+    },
+    "comment": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/comment",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "completeness": {
+      "@context": {
+        "@vocab": "https://spdx.org/rdf/3.0.1/terms/Core/RelationshipCompleteness/"
+      },
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/completeness",
+      "@type": "@vocab"
+    },
+    "contentType": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/contentType",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "context": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/context",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "created": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/created",
+      "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
+    },
+    "createdBy": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/createdBy",
+      "@type": "@vocab"
+    },
+    "createdUsing": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/createdUsing",
+      "@type": "@vocab"
+    },
+    "creationInfo": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/creationInfo",
+      "@type": "@vocab"
+    },
+    "dataLicense": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/dataLicense",
+      "@type": "@vocab"
+    },
+    "dataset_ConfidentialityLevelType": "https://spdx.org/rdf/3.0.1/terms/Dataset/ConfidentialityLevelType",
+    "dataset_DatasetAvailabilityType": "https://spdx.org/rdf/3.0.1/terms/Dataset/DatasetAvailabilityType",
+    "dataset_DatasetPackage": "https://spdx.org/rdf/3.0.1/terms/Dataset/DatasetPackage",
+    "dataset_DatasetType": "https://spdx.org/rdf/3.0.1/terms/Dataset/DatasetType",
+    "dataset_anonymizationMethodUsed": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Dataset/anonymizationMethodUsed",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "dataset_confidentialityLevel": {
+      "@context": {
+        "@vocab": "https://spdx.org/rdf/3.0.1/terms/Dataset/ConfidentialityLevelType/"
+      },
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Dataset/confidentialityLevel",
+      "@type": "@vocab"
+    },
+    "dataset_dataCollectionProcess": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Dataset/dataCollectionProcess",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "dataset_dataPreprocessing": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Dataset/dataPreprocessing",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "dataset_datasetAvailability": {
+      "@context": {
+        "@vocab": "https://spdx.org/rdf/3.0.1/terms/Dataset/DatasetAvailabilityType/"
+      },
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Dataset/datasetAvailability",
+      "@type": "@vocab"
+    },
+    "dataset_datasetNoise": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Dataset/datasetNoise",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "dataset_datasetSize": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Dataset/datasetSize",
+      "@type": "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+    },
+    "dataset_datasetType": {
+      "@context": {
+        "@vocab": "https://spdx.org/rdf/3.0.1/terms/Dataset/DatasetType/"
+      },
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Dataset/datasetType",
+      "@type": "@vocab"
+    },
+    "dataset_datasetUpdateMechanism": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Dataset/datasetUpdateMechanism",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "dataset_hasSensitivePersonalInformation": {
+      "@context": {
+        "@vocab": "https://spdx.org/rdf/3.0.1/terms/Core/PresenceType/"
+      },
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Dataset/hasSensitivePersonalInformation",
+      "@type": "@vocab"
+    },
+    "dataset_intendedUse": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Dataset/intendedUse",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "dataset_knownBias": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Dataset/knownBias",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "dataset_sensor": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Dataset/sensor",
+      "@type": "@vocab"
+    },
+    "definingArtifact": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/definingArtifact",
+      "@type": "@vocab"
+    },
+    "description": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/description",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "element": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/element",
+      "@type": "@vocab"
+    },
+    "endIntegerRange": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/endIntegerRange",
+      "@type": "http://www.w3.org/2001/XMLSchema#positiveInteger"
+    },
+    "endTime": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/endTime",
+      "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
+    },
+    "expandedlicensing_ConjunctiveLicenseSet": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/ConjunctiveLicenseSet",
+    "expandedlicensing_CustomLicense": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/CustomLicense",
+    "expandedlicensing_CustomLicenseAddition": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/CustomLicenseAddition",
+    "expandedlicensing_DisjunctiveLicenseSet": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/DisjunctiveLicenseSet",
+    "expandedlicensing_ExtendableLicense": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/ExtendableLicense",
+    "expandedlicensing_IndividualLicensingInfo": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/IndividualLicensingInfo",
+    "expandedlicensing_License": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/License",
+    "expandedlicensing_LicenseAddition": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/LicenseAddition",
+    "expandedlicensing_ListedLicense": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/ListedLicense",
+    "expandedlicensing_ListedLicenseException": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/ListedLicenseException",
+    "expandedlicensing_NoAssertionLicense": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/NoAssertionLicense",
+    "expandedlicensing_NoneLicense": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/NoneLicense",
+    "expandedlicensing_OrLaterOperator": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/OrLaterOperator",
+    "expandedlicensing_WithAdditionOperator": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/WithAdditionOperator",
+    "expandedlicensing_additionText": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/additionText",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "expandedlicensing_deprecatedVersion": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/deprecatedVersion",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "expandedlicensing_isDeprecatedAdditionId": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/isDeprecatedAdditionId",
+      "@type": "http://www.w3.org/2001/XMLSchema#boolean"
+    },
+    "expandedlicensing_isDeprecatedLicenseId": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/isDeprecatedLicenseId",
+      "@type": "http://www.w3.org/2001/XMLSchema#boolean"
+    },
+    "expandedlicensing_isFsfLibre": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/isFsfLibre",
+      "@type": "http://www.w3.org/2001/XMLSchema#boolean"
+    },
+    "expandedlicensing_isOsiApproved": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/isOsiApproved",
+      "@type": "http://www.w3.org/2001/XMLSchema#boolean"
+    },
+    "expandedlicensing_licenseXml": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/licenseXml",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "expandedlicensing_listVersionAdded": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/listVersionAdded",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "expandedlicensing_member": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/member",
+      "@type": "@vocab"
+    },
+    "expandedlicensing_obsoletedBy": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/obsoletedBy",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "expandedlicensing_seeAlso": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/seeAlso",
+      "@type": "http://www.w3.org/2001/XMLSchema#anyURI"
+    },
+    "expandedlicensing_standardAdditionTemplate": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/standardAdditionTemplate",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "expandedlicensing_standardLicenseHeader": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/standardLicenseHeader",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "expandedlicensing_standardLicenseTemplate": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/standardLicenseTemplate",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "expandedlicensing_subjectAddition": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/subjectAddition",
+      "@type": "@vocab"
+    },
+    "expandedlicensing_subjectExtendableLicense": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/subjectExtendableLicense",
+      "@type": "@vocab"
+    },
+    "expandedlicensing_subjectLicense": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing/subjectLicense",
+      "@type": "@vocab"
+    },
+    "extension": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/extension",
+      "@type": "@vocab"
+    },
+    "extension_CdxPropertiesExtension": "https://spdx.org/rdf/3.0.1/terms/Extension/CdxPropertiesExtension",
+    "extension_CdxPropertyEntry": "https://spdx.org/rdf/3.0.1/terms/Extension/CdxPropertyEntry",
+    "extension_Extension": "https://spdx.org/rdf/3.0.1/terms/Extension/Extension",
+    "extension_cdxPropName": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Extension/cdxPropName",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "extension_cdxPropValue": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Extension/cdxPropValue",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "extension_cdxProperty": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Extension/cdxProperty",
+      "@type": "@vocab"
+    },
+    "externalIdentifier": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/externalIdentifier",
+      "@type": "@vocab"
+    },
+    "externalIdentifierType": {
+      "@context": {
+        "@vocab": "https://spdx.org/rdf/3.0.1/terms/Core/ExternalIdentifierType/"
+      },
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/externalIdentifierType",
+      "@type": "@vocab"
+    },
+    "externalRef": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/externalRef",
+      "@type": "@vocab"
+    },
+    "externalRefType": {
+      "@context": {
+        "@vocab": "https://spdx.org/rdf/3.0.1/terms/Core/ExternalRefType/"
+      },
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/externalRefType",
+      "@type": "@vocab"
+    },
+    "externalSpdxId": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/externalSpdxId",
+      "@type": "http://www.w3.org/2001/XMLSchema#anyURI"
+    },
+    "from": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/from",
+      "@type": "@vocab"
+    },
+    "hashValue": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/hashValue",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "identifier": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/identifier",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "identifierLocator": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/identifierLocator",
+      "@type": "http://www.w3.org/2001/XMLSchema#anyURI"
+    },
+    "import": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/import",
+      "@type": "@vocab"
+    },
+    "issuingAuthority": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/issuingAuthority",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "key": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/key",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "locationHint": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/locationHint",
+      "@type": "http://www.w3.org/2001/XMLSchema#anyURI"
+    },
+    "locator": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/locator",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "name": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/name",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "namespace": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/namespace",
+      "@type": "http://www.w3.org/2001/XMLSchema#anyURI"
+    },
+    "namespaceMap": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/namespaceMap",
+      "@type": "@vocab"
+    },
+    "originatedBy": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/originatedBy",
+      "@type": "@vocab"
+    },
+    "packageVerificationCodeExcludedFile": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/packageVerificationCodeExcludedFile",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "prefix": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/prefix",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "profileConformance": {
+      "@context": {
+        "@vocab": "https://spdx.org/rdf/3.0.1/terms/Core/ProfileIdentifierType/"
+      },
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/profileConformance",
+      "@type": "@vocab"
+    },
+    "relationshipType": {
+      "@context": {
+        "@vocab": "https://spdx.org/rdf/3.0.1/terms/Core/RelationshipType/"
+      },
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/relationshipType",
+      "@type": "@vocab"
+    },
+    "releaseTime": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/releaseTime",
+      "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
+    },
+    "rootElement": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/rootElement",
+      "@type": "@vocab"
+    },
+    "scope": {
+      "@context": {
+        "@vocab": "https://spdx.org/rdf/3.0.1/terms/Core/LifecycleScopeType/"
+      },
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/scope",
+      "@type": "@vocab"
+    },
+    "security_CvssSeverityType": "https://spdx.org/rdf/3.0.1/terms/Security/CvssSeverityType",
+    "security_CvssV2VulnAssessmentRelationship": "https://spdx.org/rdf/3.0.1/terms/Security/CvssV2VulnAssessmentRelationship",
+    "security_CvssV3VulnAssessmentRelationship": "https://spdx.org/rdf/3.0.1/terms/Security/CvssV3VulnAssessmentRelationship",
+    "security_CvssV4VulnAssessmentRelationship": "https://spdx.org/rdf/3.0.1/terms/Security/CvssV4VulnAssessmentRelationship",
+    "security_EpssVulnAssessmentRelationship": "https://spdx.org/rdf/3.0.1/terms/Security/EpssVulnAssessmentRelationship",
+    "security_ExploitCatalogType": "https://spdx.org/rdf/3.0.1/terms/Security/ExploitCatalogType",
+    "security_ExploitCatalogVulnAssessmentRelationship": "https://spdx.org/rdf/3.0.1/terms/Security/ExploitCatalogVulnAssessmentRelationship",
+    "security_SsvcDecisionType": "https://spdx.org/rdf/3.0.1/terms/Security/SsvcDecisionType",
+    "security_SsvcVulnAssessmentRelationship": "https://spdx.org/rdf/3.0.1/terms/Security/SsvcVulnAssessmentRelationship",
+    "security_VexAffectedVulnAssessmentRelationship": "https://spdx.org/rdf/3.0.1/terms/Security/VexAffectedVulnAssessmentRelationship",
+    "security_VexFixedVulnAssessmentRelationship": "https://spdx.org/rdf/3.0.1/terms/Security/VexFixedVulnAssessmentRelationship",
+    "security_VexJustificationType": "https://spdx.org/rdf/3.0.1/terms/Security/VexJustificationType",
+    "security_VexNotAffectedVulnAssessmentRelationship": "https://spdx.org/rdf/3.0.1/terms/Security/VexNotAffectedVulnAssessmentRelationship",
+    "security_VexUnderInvestigationVulnAssessmentRelationship": "https://spdx.org/rdf/3.0.1/terms/Security/VexUnderInvestigationVulnAssessmentRelationship",
+    "security_VexVulnAssessmentRelationship": "https://spdx.org/rdf/3.0.1/terms/Security/VexVulnAssessmentRelationship",
+    "security_VulnAssessmentRelationship": "https://spdx.org/rdf/3.0.1/terms/Security/VulnAssessmentRelationship",
+    "security_Vulnerability": "https://spdx.org/rdf/3.0.1/terms/Security/Vulnerability",
+    "security_actionStatement": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Security/actionStatement",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "security_actionStatementTime": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Security/actionStatementTime",
+      "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
+    },
+    "security_assessedElement": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Security/assessedElement",
+      "@type": "@vocab"
+    },
+    "security_catalogType": {
+      "@context": {
+        "@vocab": "https://spdx.org/rdf/3.0.1/terms/Security/ExploitCatalogType/"
+      },
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Security/catalogType",
+      "@type": "@vocab"
+    },
+    "security_decisionType": {
+      "@context": {
+        "@vocab": "https://spdx.org/rdf/3.0.1/terms/Security/SsvcDecisionType/"
+      },
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Security/decisionType",
+      "@type": "@vocab"
+    },
+    "security_exploited": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Security/exploited",
+      "@type": "http://www.w3.org/2001/XMLSchema#boolean"
+    },
+    "security_impactStatement": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Security/impactStatement",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "security_impactStatementTime": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Security/impactStatementTime",
+      "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
+    },
+    "security_justificationType": {
+      "@context": {
+        "@vocab": "https://spdx.org/rdf/3.0.1/terms/Security/VexJustificationType/"
+      },
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Security/justificationType",
+      "@type": "@vocab"
+    },
+    "security_locator": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Security/locator",
+      "@type": "http://www.w3.org/2001/XMLSchema#anyURI"
+    },
+    "security_modifiedTime": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Security/modifiedTime",
+      "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
+    },
+    "security_percentile": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Security/percentile",
+      "@type": "http://www.w3.org/2001/XMLSchema#decimal"
+    },
+    "security_probability": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Security/probability",
+      "@type": "http://www.w3.org/2001/XMLSchema#decimal"
+    },
+    "security_publishedTime": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Security/publishedTime",
+      "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
+    },
+    "security_score": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Security/score",
+      "@type": "http://www.w3.org/2001/XMLSchema#decimal"
+    },
+    "security_severity": {
+      "@context": {
+        "@vocab": "https://spdx.org/rdf/3.0.1/terms/Security/CvssSeverityType/"
+      },
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Security/severity",
+      "@type": "@vocab"
+    },
+    "security_statusNotes": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Security/statusNotes",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "security_vectorString": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Security/vectorString",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "security_vexVersion": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Security/vexVersion",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "security_withdrawnTime": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Security/withdrawnTime",
+      "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
+    },
+    "simplelicensing_AnyLicenseInfo": "https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/AnyLicenseInfo",
+    "simplelicensing_LicenseExpression": "https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/LicenseExpression",
+    "simplelicensing_SimpleLicensingText": "https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/SimpleLicensingText",
+    "simplelicensing_customIdToUri": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/customIdToUri",
+      "@type": "@vocab"
+    },
+    "simplelicensing_licenseExpression": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/licenseExpression",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "simplelicensing_licenseListVersion": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/licenseListVersion",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "simplelicensing_licenseText": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/SimpleLicensing/licenseText",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "software_ContentIdentifier": "https://spdx.org/rdf/3.0.1/terms/Software/ContentIdentifier",
+    "software_ContentIdentifierType": "https://spdx.org/rdf/3.0.1/terms/Software/ContentIdentifierType",
+    "software_File": "https://spdx.org/rdf/3.0.1/terms/Software/File",
+    "software_FileKindType": "https://spdx.org/rdf/3.0.1/terms/Software/FileKindType",
+    "software_Package": "https://spdx.org/rdf/3.0.1/terms/Software/Package",
+    "software_Sbom": "https://spdx.org/rdf/3.0.1/terms/Software/Sbom",
+    "software_SbomType": "https://spdx.org/rdf/3.0.1/terms/Software/SbomType",
+    "software_Snippet": "https://spdx.org/rdf/3.0.1/terms/Software/Snippet",
+    "software_SoftwareArtifact": "https://spdx.org/rdf/3.0.1/terms/Software/SoftwareArtifact",
+    "software_SoftwarePurpose": "https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose",
+    "software_additionalPurpose": {
+      "@context": {
+        "@vocab": "https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/"
+      },
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Software/additionalPurpose",
+      "@type": "@vocab"
+    },
+    "software_attributionText": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Software/attributionText",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "software_byteRange": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Software/byteRange",
+      "@type": "https://spdx.org/rdf/3.0.1/terms/Core/PositiveIntegerRange"
+    },
+    "software_contentIdentifier": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Software/contentIdentifier",
+      "@type": "https://spdx.org/rdf/3.0.1/terms/Software/ContentIdentifier"
+    },
+    "software_contentIdentifierType": {
+      "@context": {
+        "@vocab": "https://spdx.org/rdf/3.0.1/terms/Software/ContentIdentifierType/"
+      },
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Software/contentIdentifierType",
+      "@type": "@vocab"
+    },
+    "software_contentIdentifierValue": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Software/contentIdentifierValue",
+      "@type": "http://www.w3.org/2001/XMLSchema#anyURI"
+    },
+    "software_copyrightText": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Software/copyrightText",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "software_downloadLocation": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Software/downloadLocation",
+      "@type": "http://www.w3.org/2001/XMLSchema#anyURI"
+    },
+    "software_fileKind": {
+      "@context": {
+        "@vocab": "https://spdx.org/rdf/3.0.1/terms/Software/FileKindType/"
+      },
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Software/fileKind",
+      "@type": "@vocab"
+    },
+    "software_homePage": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Software/homePage",
+      "@type": "http://www.w3.org/2001/XMLSchema#anyURI"
+    },
+    "software_lineRange": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Software/lineRange",
+      "@type": "https://spdx.org/rdf/3.0.1/terms/Core/PositiveIntegerRange"
+    },
+    "software_packageUrl": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Software/packageUrl",
+      "@type": "http://www.w3.org/2001/XMLSchema#anyURI"
+    },
+    "software_packageVersion": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Software/packageVersion",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "software_primaryPurpose": {
+      "@context": {
+        "@vocab": "https://spdx.org/rdf/3.0.1/terms/Software/SoftwarePurpose/"
+      },
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Software/primaryPurpose",
+      "@type": "@vocab"
+    },
+    "software_sbomType": {
+      "@context": {
+        "@vocab": "https://spdx.org/rdf/3.0.1/terms/Software/SbomType/"
+      },
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Software/sbomType",
+      "@type": "@vocab"
+    },
+    "software_snippetFromFile": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Software/snippetFromFile",
+      "@type": "@vocab"
+    },
+    "software_sourceInfo": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Software/sourceInfo",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "spdx": "https://spdx.org/rdf/3.0.1/terms/",
+    "spdxId": "@id",
+    "specVersion": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/specVersion",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "standardName": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/standardName",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "startTime": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/startTime",
+      "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
+    },
+    "statement": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/statement",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "subject": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/subject",
+      "@type": "@vocab"
+    },
+    "summary": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/summary",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "suppliedBy": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/suppliedBy",
+      "@type": "@vocab"
+    },
+    "supportLevel": {
+      "@context": {
+        "@vocab": "https://spdx.org/rdf/3.0.1/terms/Core/SupportType/"
+      },
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/supportLevel",
+      "@type": "@vocab"
+    },
+    "to": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/to",
+      "@type": "@vocab"
+    },
+    "type": "@type",
+    "validUntilTime": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/validUntilTime",
+      "@type": "http://www.w3.org/2001/XMLSchema#dateTimeStamp"
+    },
+    "value": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/value",
+      "@type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "verifiedUsing": {
+      "@id": "https://spdx.org/rdf/3.0.1/terms/Core/verifiedUsing",
+      "@type": "@vocab"
+    }
+  }
+}

--- a/tests/test_spdx.py
+++ b/tests/test_spdx.py
@@ -1,0 +1,458 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the SPDX 3.0 JSON-LD renderer.
+
+The renderer is a pure function over the Report dataclass.  We build a
+synthetic Report with one of every detection source populated, render
+the SPDX document, and validate against the bundled SPDX 3.0.1 JSON-LD
+context.  SPDX 3.0.1 does not publish a JSON Schema (validation is via
+OWL/SHACL), so the structural validator implements the minimum invariants
+the spec requires for a JSON-LD-serialised SPDX document:
+
+  - top-level @context resolves to the canonical 3.0.1 context URL
+  - top-level @graph is an array of SPDX objects
+  - every object's `type` is a class defined in the bundled context
+  - every property used on an object is a term in the bundled context
+  - every Element (anything with `spdxId`) carries a CreationInfo with
+    specVersion, created, createdBy
+  - every reference (CreationInfo.createdBy, Sbom.element, etc.) resolves
+    to an spdxId or @id within the same document
+
+We bundle the official context file under tests/fixtures/spdx/ so CI is
+hermetic — no network calls during pytest."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+import pqc_readiness as pr
+from conftest import FIXTURES
+
+SPDX_CONTEXT_PATH = FIXTURES / "spdx" / "spdx-3.0.1-context.jsonld"
+
+# Property keys that are JSON-LD reserved or expected aliases that the
+# context does not need to map (the spec normatively defines them).
+JSONLD_BUILTINS = frozenset({"@context", "@graph", "@id", "@type"})
+
+# Keys used universally on Elements.  `type` and `spdxId` are aliased
+# via the SPDX 3.0.1 context to @type and @id respectively, so they
+# already appear as terms; this set is for keys that some validators
+# treat as core JSON-LD scaffolding.
+ELEMENT_REQUIRED_KEYS = ("type", "spdxId", "creationInfo", "name")
+
+
+def _load_context() -> dict[str, Any]:
+    return json.loads(SPDX_CONTEXT_PATH.read_text())["@context"]
+
+
+def _make_report() -> pr.Report:
+    """A synthetic Report covering every input source the SPDX renderer
+    consumes.  Mirrors tests/test_cbom.py::_make_report so that both
+    renderers are tested against the same input shape."""
+    return pr.Report(
+        generated_at="2026-04-28T12:00:00+00:00",
+        hostname="testhost.example",
+        os="Fedora Linux 44 (Workstation Edition)",
+        arch="x86_64",
+        cpu_model="Test CPU",
+        cores_logical=8,
+        cores_physical=8,
+        mem_total_gb=32.0,
+        mem_avail_gb=24.0,
+        isa_features={
+            "avx512ifma": {
+                "name": "AVX-512 IFMA",
+                "purpose": "52-bit FMA; lattice multiplication",
+                "weight": "3",
+            },
+            "avx512vbmi": {
+                "name": "AVX-512 VBMI",
+                "purpose": "Permute-bytes; major Keccak speedup",
+                "weight": "3",
+            },
+        },
+        accelerators=[
+            {
+                "kind": "hsm",
+                "name": "Test HSM",
+                "detail": "PCI vendor:device",
+                "pqc_capable": False,
+            },
+        ],
+        pkcs11_modules=["/usr/lib64/pkcs11/libfoo.so"],
+        tpm_pqc={
+            "present": True,
+            "pqc_advertised": False,
+            "note": "TPM 2.0 PQC algorithms not advertised",
+        },
+        openssl={
+            "available": True,
+            "version": "3.5.5",
+            "pqc_native": True,
+            "kem_algorithms": ["ML-KEM-768"],
+            "sig_algorithms": ["ML-DSA-65", "SLH-DSA-SHA2-128s"],
+            "tls_groups": {
+                "hybrid": ["X25519MLKEM768"],
+                "pure_pqc": ["MLKEM768"],
+                "classical": ["X25519"],
+            },
+        },
+        ssh_pqc={
+            "available": True,
+            "version": "9.9p1",
+            "kex_groups": {
+                "hybrid": ["mlkem768x25519-sha256"],
+                "pure_pqc": [],
+            },
+        },
+        ipsec_pqc={
+            "available": True,
+            "implementation": "strongswan",
+            "pqc": True,
+            "evidence": "ML-KEM",
+        },
+        trust_store={
+            "available": True,
+            "scanned_dirs": ["/etc/pki/ca-trust/extracted/pem"],
+            "total_certs": 142,
+            "pqc_certs": 0,
+            "hybrid_certs": 0,
+        },
+        # Findings: trigger the SLH-DSA-in-TLS rule plus the
+        # classical-only-trust-store rule via the inputs above.
+        replace_required=False,
+        fips={"kernel": False},
+    )
+
+
+def _validate_against_context(doc: dict[str, Any]) -> None:
+    """Structural validator for SPDX 3.0.1 JSON-LD output.
+
+    Mirrors the constraints in the SPDX 3.0.1 spec's JSON-LD
+    serialization section without requiring a SHACL/OWL toolchain in CI:
+
+      - @context references the canonical 3.0.1 URL
+      - every @graph entry's `type` is a class in the bundled context
+      - every property key on an entry is a term in the bundled context
+      - every Element has the CreationInfo invariants
+    """
+    assert doc.get("@context") == pr.SPDX_CONTEXT_URL, (
+        f"@context must be {pr.SPDX_CONTEXT_URL}, got {doc.get('@context')!r}"
+    )
+    graph = doc.get("@graph")
+    assert isinstance(graph, list) and graph, "@graph must be a non-empty array"
+
+    ctx = _load_context()
+
+    for elem in graph:
+        assert isinstance(elem, dict), "every graph entry must be an object"
+        type_name = elem.get("type")
+        assert isinstance(type_name, str), "every entry must have a `type`"
+        assert type_name in ctx, (
+            f"unknown SPDX type {type_name!r} (not a term in 3.0.1 context)"
+        )
+        for key in elem.keys():
+            if key in JSONLD_BUILTINS:
+                continue
+            assert key in ctx, (
+                f"property {key!r} on type {type_name!r} is not a term in "
+                "the SPDX 3.0.1 context"
+            )
+
+    # Every Element (anything with spdxId) must carry a valid CreationInfo
+    # with the spec-required fields and a 3.0.x specVersion.
+    for elem in graph:
+        if "spdxId" not in elem:
+            continue
+        ci = elem.get("creationInfo")
+        assert isinstance(ci, dict), (
+            f"Element {elem.get('spdxId')!r} missing creationInfo"
+        )
+        assert ci.get("type") == "CreationInfo"
+        assert isinstance(ci.get("specVersion"), str)
+        assert ci["specVersion"].startswith("3.0."), (
+            f"specVersion {ci.get('specVersion')!r} not a 3.0.x value"
+        )
+        assert isinstance(ci.get("created"), str) and ci["created"]
+        created_by = ci.get("createdBy")
+        assert isinstance(created_by, list) and created_by, (
+            "CreationInfo.createdBy must be a non-empty list"
+        )
+
+    # All references (createdBy, element, rootElement, from, to,
+    # security_assessedElement) must resolve within the document.
+    spdx_ids = {e["spdxId"] for e in graph if "spdxId" in e}
+    for elem in graph:
+        ci = elem.get("creationInfo") or {}
+        for ref in ci.get("createdBy") or []:
+            assert ref in spdx_ids, f"dangling createdBy reference {ref!r}"
+        for prop in ("rootElement", "element", "to"):
+            for ref in elem.get(prop) or []:
+                assert ref in spdx_ids, (
+                    f"dangling {prop} reference {ref!r} on {elem.get('type')}"
+                )
+        for prop in ("from", "security_assessedElement"):
+            ref = elem.get(prop)
+            if isinstance(ref, str):
+                assert ref in spdx_ids, f"dangling {prop} reference {ref!r}"
+
+
+def test_render_spdx_validates_against_context() -> None:
+    r = _make_report()
+    doc = json.loads(pr.render_spdx(r))
+    _validate_against_context(doc)
+
+
+def test_render_spdx_top_level_shape() -> None:
+    r = _make_report()
+    doc = json.loads(pr.render_spdx(r))
+    assert doc["@context"] == "https://spdx.org/rdf/3.0.1/spdx-context.jsonld"
+    assert isinstance(doc["@graph"], list)
+    types = [e.get("type") for e in doc["@graph"]]
+    assert "SpdxDocument" in types
+    assert "software_Sbom" in types
+    # The host package and at least one asset package
+    assert types.count("software_Package") >= 2
+
+
+def test_render_spdx_profile_conformance_includes_security() -> None:
+    r = _make_report()
+    doc = json.loads(pr.render_spdx(r))
+    sbom = next(e for e in doc["@graph"] if e["type"] == "software_Sbom")
+    assert "security" in sbom["profileConformance"]
+    assert "software" in sbom["profileConformance"]
+    assert "core" in sbom["profileConformance"]
+
+
+def test_render_spdx_data_license_is_cc0() -> None:
+    """SPDX 3.0 documents shipped publicly conventionally use CC0 for
+    the data licence so consumers can redistribute the document text."""
+    r = _make_report()
+    doc = json.loads(pr.render_spdx(r))
+    sd = next(e for e in doc["@graph"] if e["type"] == "SpdxDocument")
+    assert sd["dataLicense"] == "https://spdx.org/licenses/CC0-1.0"
+
+
+def _by_id(graph: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    return {e["spdxId"]: e for e in graph if "spdxId" in e}
+
+
+def test_render_spdx_canonical_assets_become_packages() -> None:
+    r = _make_report()
+    doc = json.loads(pr.render_spdx(r))
+    by_id = _by_id(doc["@graph"])
+
+    expected_keys = {a.key for a in pr.canonical_assets(r)}
+    assert expected_keys, "test setup should produce canonical assets"
+
+    asset_ids = [
+        spdx_id
+        for spdx_id in by_id
+        if ":asset:" in spdx_id and by_id[spdx_id]["type"] == "software_Package"
+    ]
+    assert len(asset_ids) == len(expected_keys), (
+        "every canonical asset must be projected to one software_Package"
+    )
+
+    # Every emitted package's description carries the canonical
+    # category=… line so consumers can correlate with --cbom output.
+    for spdx_id in asset_ids:
+        desc = by_id[spdx_id].get("description", "")
+        assert re.search(r"^category=", desc, re.MULTILINE), (
+            f"asset package {spdx_id!r} missing category= in description"
+        )
+
+
+def test_render_spdx_pqc_algorithm_metadata_is_preserved() -> None:
+    r = _make_report()
+    doc = json.loads(pr.render_spdx(r))
+    by_id = _by_id(doc["@graph"])
+
+    ml_kem = next(
+        e
+        for e in by_id.values()
+        if e["type"] == "software_Package" and e.get("name") == "ML-KEM-768"
+    )
+    # ML-KEM-768 is NIST PQC category 3 with parameter set "768"
+    assert ml_kem["software_packageVersion"] == "768"
+    ext_ids = ml_kem.get("externalIdentifier") or []
+    assert any(
+        ei.get("identifier") == "nist-pqc-category-3" for ei in ext_ids
+    ), "expected NIST category 3 externalIdentifier on ML-KEM-768"
+
+
+def test_render_spdx_findings_become_security_vulnerabilities() -> None:
+    """The SARIF rule predicates fire the same way for SPDX — each
+    finding becomes a security_Vulnerability + a VEX `affects`
+    relationship to the host."""
+    r = _make_report()
+    doc = json.loads(pr.render_spdx(r))
+    findings = pr.build_findings(r)
+    assert findings, "test fixture should produce at least one finding"
+
+    vulns = [e for e in doc["@graph"] if e["type"] == "security_Vulnerability"]
+    vex = [
+        e
+        for e in doc["@graph"]
+        if e["type"] == "security_VexAffectedVulnAssessmentRelationship"
+    ]
+    assert len(vulns) == len(findings)
+    assert len(vex) == len(findings)
+
+    finding_ids = {f.rule_id for f in findings}
+    vuln_rule_ids = {
+        ext.get("identifier")
+        for v in vulns
+        for ext in v.get("externalIdentifier") or []
+    }
+    assert finding_ids <= vuln_rule_ids
+
+
+def test_render_spdx_vex_relationships_reference_host() -> None:
+    r = _make_report()
+    doc = json.loads(pr.render_spdx(r))
+    by_id = _by_id(doc["@graph"])
+    host_id = next(
+        spdx_id
+        for spdx_id, e in by_id.items()
+        if e["type"] == "software_Package" and spdx_id.endswith(":host")
+    )
+    vex = [
+        e
+        for e in doc["@graph"]
+        if e["type"] == "security_VexAffectedVulnAssessmentRelationship"
+    ]
+    for rel in vex:
+        assert rel["relationshipType"] == "affects"
+        assert rel["from"] in by_id
+        assert by_id[rel["from"]]["type"] == "security_Vulnerability"
+        assert host_id in rel["to"]
+        assert rel["security_assessedElement"] == host_id
+
+
+def test_render_spdx_creator_agent_is_self_referencing() -> None:
+    """Every Element's CreationInfo.createdBy must resolve in-document.
+    The pqc-readiness SoftwareAgent is the bootstrap creator and is its
+    own createdBy — that self-reference is permitted by the spec and
+    keeps the document closed (no external Agent registry required)."""
+    r = _make_report()
+    doc = json.loads(pr.render_spdx(r))
+    by_id = _by_id(doc["@graph"])
+    agent = next(e for e in by_id.values() if e["type"] == "SoftwareAgent")
+    self_id = agent["spdxId"]
+    assert agent["creationInfo"]["createdBy"] == [self_id]
+    # Every other element should also reference this same creator.
+    for spdx_id, e in by_id.items():
+        if spdx_id == self_id:
+            continue
+        assert e["creationInfo"]["createdBy"] == [self_id]
+
+
+def test_render_spdx_empty_report_still_validates() -> None:
+    """An empty Report must still produce a structurally-valid SPDX 3.0
+    document — SpdxDocument + Sbom + host package + creator, no
+    cryptographic asset packages, no findings."""
+    r = pr.Report(
+        generated_at="2026-04-28T12:00:00+00:00",
+        hostname="bare",
+        arch="aarch64",
+    )
+    doc = json.loads(pr.render_spdx(r))
+    _validate_against_context(doc)
+    types = [e["type"] for e in doc["@graph"]]
+    assert "SpdxDocument" in types
+    assert "software_Sbom" in types
+    # exactly one software_Package: the host (no canonical assets).
+    assert types.count("software_Package") == 1
+    assert "security_Vulnerability" not in types
+
+
+def test_render_spdx_same_canonical_inputs_as_cbom() -> None:
+    """The acceptance criterion: --cbom and --spdx project from the same
+    canonical asset list, no detection-logic duplication."""
+    r = _make_report()
+    canonical = pr.canonical_assets(r)
+    cbom = json.loads(pr.render_cbom(r))
+    spdx = json.loads(pr.render_spdx(r))
+
+    cbom_names = sorted(c["name"] for c in cbom["components"])
+    spdx_asset_names = sorted(
+        e.get("name", "")
+        for e in spdx["@graph"]
+        if e.get("type") == "software_Package" and ":asset:" in e.get("spdxId", "")
+    )
+    expected_names = sorted(a.name for a in canonical)
+    assert cbom_names == expected_names
+    assert spdx_asset_names == expected_names
+
+
+def test_render_spdx_arch_appears_in_host_package() -> None:
+    """Host context (OS / arch) is surfaced on the host software_Package
+    so SPDX consumers can filter by platform without parsing CBOM."""
+    cases = ["x86_64", "aarch64", "s390x"]
+    for arch in cases:
+        r = pr.Report(
+            generated_at="2026-04-28T12:00:00+00:00",
+            hostname="h",
+            arch=arch,
+            os="Some OS",
+        )
+        doc = json.loads(pr.render_spdx(r))
+        host = next(
+            e
+            for e in doc["@graph"]
+            if e.get("type") == "software_Package"
+            and e.get("spdxId", "").endswith(":host")
+        )
+        assert arch in host.get("summary", "")
+
+
+def test_cli_spdx_flag_routes_to_render_spdx(monkeypatch, capsys) -> None:
+    """The --spdx CLI flag must produce the same output as
+    render_spdx() so contract tests can hit either path."""
+    fake_report = pr.Report(
+        generated_at="2026-04-28T12:00:00+00:00",
+        hostname="cliprobe",
+        arch="x86_64",
+    )
+    monkeypatch.setattr(pr, "render_spdx", lambda r: '{"@context":"x"}')
+    # Bypass the long detection pipeline by patching the heavy probes.
+    monkeypatch.setattr(pr, "cpu_flags", lambda arch: set())
+    monkeypatch.setattr(pr, "memory_info", lambda: (1.0, 1.0))
+    monkeypatch.setattr(pr, "core_counts", lambda: (1, 1))
+    monkeypatch.setattr(pr, "detect_isa", lambda *_a, **_k: ({}, 0))
+    monkeypatch.setattr(pr, "isa_tier", lambda *_a, **_k: ("poor", "no SIMD"))
+    monkeypatch.setattr(pr, "memory_tier", lambda *_a, **_k: ("poor", "low RAM"))
+    monkeypatch.setattr(pr, "detect_runtime_environment", lambda: {})
+    monkeypatch.setattr(pr, "detect_accelerators", lambda: [])
+    monkeypatch.setattr(pr, "detect_network_hsms", lambda: [])
+    monkeypatch.setattr(pr, "detect_os", lambda: {"family": "fedora"})
+    monkeypatch.setattr(pr, "detect_pkcs11_modules", lambda *_a, **_k: [])
+    monkeypatch.setattr(pr, "detect_kernel_crypto_hw", lambda: [])
+    monkeypatch.setattr(pr, "detect_ktls", lambda: None)
+    monkeypatch.setattr(pr, "detect_fips_mode", lambda: {})
+    monkeypatch.setattr(pr, "detect_tpm_pqc", lambda: {})
+    monkeypatch.setattr(
+        pr,
+        "openssl_capability",
+        lambda *_a, **_k: {"available": False},
+    )
+    monkeypatch.setattr(pr, "detect_ssh_pqc", lambda *_a, **_k: {})
+    monkeypatch.setattr(pr, "detect_ipsec_pqc", lambda *_a, **_k: {})
+    monkeypatch.setattr(pr, "detect_nss", lambda: {})
+    monkeypatch.setattr(pr, "detect_kernel_info", lambda *_a, **_k: {})
+    monkeypatch.setattr(pr, "interpret_fips", lambda *_a, **_k: {"kernel": False})
+    monkeypatch.setattr(pr, "fips_pqc_conflict_check", lambda *_a, **_k: {})
+    monkeypatch.setattr(pr, "evaluate_cnsa_2_0", lambda *_a, **_k: {})
+    monkeypatch.setattr(pr, "has_dedicated_pqc_silicon", lambda *_a, **_k: False)
+    monkeypatch.setattr(
+        pr, "overall_verdict", lambda *_a, **_k: ("poor", "low", 3, "")
+    )
+
+    monkeypatch.setattr("sys.argv", ["pqc-readiness", "--spdx", "--no-color"])
+    rc = pr.main()
+    out = capsys.readouterr().out
+    assert rc == 3  # poor verdict exit code, unchanged
+    assert out.strip() == '{"@context":"x"}'
+    _ = fake_report  # silence unused-warning if linters don't see monkeypatching


### PR DESCRIPTION
## Summary

- Refactors the CBOM internals into a canonical \`CryptoAsset\` model so both \`--cbom\` (CycloneDX 1.6) and the new \`--spdx\` output project from the same detection pipeline — no duplicated detection logic.
- Adds \`render_spdx(r)\` which emits an SPDX 3.0.1 JSON-LD document with \`profileConformance = [core, software, security]\`. Each canonical asset becomes a \`software_Package\`; each finding (the same predicates the SARIF renderer uses) becomes a \`security_Vulnerability\` plus a \`security_VexAffectedVulnAssessmentRelationship\` linking it to the host package.
- Wires the \`--spdx\` CLI flag, updates the script docstring, and documents the format in README.md.

## Acceptance criteria (issue #6)

- [x] New \`--spdx\` flag emits SPDX 3.0 JSON-LD with cryptographic findings under the Security profile
- [x] Output validates against the SPDX 3.0 schema (structural validator over the bundled JSON-LD context — SPDX 3.0.1 does not ship a JSON Schema; OWL/SHACL is the canonical validation surface)
- [x] Same source data as \`--cbom\` — no detection logic duplication (both renderers project from \`canonical_assets()\`)

## Notes on validation

SPDX 3.0.1 publishes a JSON-LD context but no JSON Schema. \`tests/test_spdx.py\` bundles the official context file under \`tests/fixtures/spdx/\` (so CI is hermetic) and runs a structural validator that mirrors the spec's required-shape invariants: top-level \`@context\` + \`@graph\`, every \`type\`/property is a known term, every reference resolves within the document, every Element carries a \`CreationInfo\` with \`specVersion\` 3.0.x.

## Test plan

- [x] \`pytest -x\` — 230 tests pass (217 prior + 13 new SPDX tests)
- [x] \`scripts/check-no-third-party-refs.sh\` — clean
- [x] CBOM output is byte-equivalent to the previous implementation modulo per-builder source-property duplication (now emitted once via the canonical \`source\` field)
- [x] SPDX output validates against bundled SPDX 3.0.1 JSON-LD context
- [x] \`--spdx\` and \`--cbom\` outputs cover the same set of canonical assets

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)