### PR TITLE
docs: Ansible integration guide + runnable playbooks under deploy/ansible/

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,11 +76,16 @@ README in the same PR:
 - Any change to the `--help` text that affects the documented behaviour
   of an existing flag.
 - Any change to exit codes.
+- Any change that affects the `--ansible` output, the privilege /
+  `become` model the script depends on, or the example playbooks under
+  `deploy/ansible/` must keep [`docs/ansible.md`](docs/ansible.md) and
+  the playbooks in sync in the same PR.
 
 The README must, at minimum, name the flag or field and describe its
 purpose in one sentence. Detailed reference may live in a linked file
 under `docs/` (for example `docs/scope.md`,
-`docs/recommendation-policies.md`), but the README must point at it.
+`docs/recommendation-policies.md`, `docs/ansible.md`), but the README
+must point at it.
 
 Verifying coverage locally:
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ authoritative one-line summary.
 | `--cbom` | Emit a CycloneDX 1.6 Cryptographic Bill of Materials (see [CBOM output](#cbom-output---cbom)). |
 | `--spdx` | Emit an SPDX 3.0 JSON-LD document with the Security profile (see [SPDX 3.0 output](#spdx-30-output---spdx)). |
 | `--sarif` | Emit SARIF 2.1.0 findings for security pipelines (see [SARIF output](#sarif-output---sarif)). |
-| `--ansible` | Wrap the JSON schema in `{ansible_facts: {pqc_readiness: ...}}` and exit 0. Intended for `ansible.builtin.set_fact`. |
+| `--ansible` | Wrap the JSON schema in `{ansible_facts: {pqc_readiness: ...}}` and exit 0. See [`docs/ansible.md`](docs/ansible.md) for runnable playbooks (`set_fact`, fleet aggregation), the privilege model, and the fact shape downstream tasks can rely on. |
 
 `--json`, `--cbom`, `--spdx`, and `--sarif` are mutually exclusive views
 over the same probe run. The default (no flag) is the human-readable
@@ -209,7 +209,9 @@ keep the same version. Aggregation refuses to merge files whose
 | `exit_code` | Numeric exit code the program will return. Mirrors the [Exit codes](#exit-codes) table. |
 
 `--ansible` returns a single top-level key `ansible_facts`, whose value
-is `{pqc_readiness: {…the schema above…}}`.
+is `{pqc_readiness: {…the schema above…}}`. See
+[`docs/ansible.md`](docs/ansible.md) for runnable playbooks, the
+become / privilege model, and downstream `set_fact` patterns.
 
 `--recommend --json` returns a different document with top-level keys
 `role`, `mode`, `hostname`, `generated_at`, and `recommendations`. The
@@ -337,6 +339,10 @@ a reason rather than silently merged.
 - [`docs/recommendation-policies.md`](docs/recommendation-policies.md) —
   authority, source documents, and engine-encoded position for every
   policy reachable through `--policy`.
+- [`docs/ansible.md`](docs/ansible.md) — runnable Ansible playbooks
+  (`set_fact`, fleet aggregation), privilege model, and the fact shape
+  downstream tasks can rely on. Example playbooks live under
+  [`deploy/ansible/`](deploy/ansible/).
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — third-party product reference
   policy and the rule that keeps this README in sync with `--help`.
 

--- a/deploy/ansible/inventory.example.ini
+++ b/deploy/ansible/inventory.example.ini
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal example inventory referenced by the playbooks in this
+# directory.  Replace the host entries with your own.  The two groups
+# (`pqc_targets` and `controller`) match the role split in
+# `playbook-fleet-aggregate.yml`: targets run the probe, the controller
+# (which can be `localhost`) collects results and runs the rollup.
+
+[pqc_targets]
+host1.example.test
+host2.example.test
+host3.example.test
+
+[pqc_targets:vars]
+ansible_user=ansible
+# Set ansible_python_interpreter when targeting RHEL 8 / Rocky 8 /
+# AlmaLinux 8 fleets — the AppStream `python39` module exposes
+# /usr/bin/python3.9, which Ansible cannot autodiscover by default.
+# ansible_python_interpreter=/usr/bin/python3.9
+
+[controller]
+localhost ansible_connection=local

--- a/deploy/ansible/playbook-fleet-aggregate.yml
+++ b/deploy/ansible/playbook-fleet-aggregate.yml
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Two-phase fleet rollup: each target host runs the probe and writes a
+# JSON file, then the controller fetches every file and runs
+# `pqc_readiness.py --aggregate` over the collected directory to produce
+# a single fleet-wide rollup.
+#
+# This mirrors the pattern documented under "Aggregation" in README.md:
+# the same `--aggregate DIR` mode that consumes the DaemonSet output
+# volume on OpenShift consumes the Ansible-fetched directory here.
+#
+# Layout on the controller:
+#
+#   {{ rollup_dir }}/
+#     <hostname>.json     one per target
+#     fleet-rollup.json   the --aggregate output
+#
+# Validated against `ansible-core 2.20.5`.
+---
+- name: Phase 1 — run the probe on every target and emit JSON
+  hosts: pqc_targets
+  gather_facts: false
+  # `rollup_dir` is declared in both phases so Phase 1 can resolve the
+  # fetch destination without reaching into `hostvars['localhost']`,
+  # which is not yet populated when this play runs.  `playbook_dir`
+  # resolves identically on every host context.
+  vars:
+    rollup_dir: "{{ playbook_dir }}/.rollup"
+    target_output: /var/tmp/pqc-readiness.json
+  tasks:
+    - name: Run pqc-readiness with --json
+      ansible.builtin.script:
+        cmd: "../../pqc_readiness.py --json"
+      register: pqc_raw
+      changed_when: false
+
+    - name: Write JSON to a known path on the target
+      ansible.builtin.copy:
+        content: "{{ pqc_raw.stdout }}"
+        dest: "{{ target_output }}"
+        mode: "0644"
+      changed_when: false
+
+    - name: Fetch the JSON back to the controller
+      ansible.builtin.fetch:
+        src: "{{ target_output }}"
+        dest: "{{ rollup_dir }}/{{ inventory_hostname }}.json"
+        flat: true
+
+- name: Phase 2 — controller-side aggregation
+  hosts: controller
+  gather_facts: false
+  vars:
+    rollup_dir: "{{ playbook_dir }}/.rollup"
+    aggregate_output: "{{ rollup_dir }}/fleet-rollup.json"
+  tasks:
+    - name: Ensure the rollup directory exists
+      ansible.builtin.file:
+        path: "{{ rollup_dir }}"
+        state: directory
+        mode: "0755"
+
+    # The aggregator is idempotent over the input directory — we want a
+    # fresh rollup on every run, so no `creates:` guard.
+    - name: Run --aggregate on the collected JSON
+      ansible.builtin.shell:
+        cmd: >-
+          {{ playbook_dir }}/../../pqc_readiness.py
+          --aggregate {{ rollup_dir }}
+          > {{ aggregate_output }}
+      changed_when: true
+
+    - name: Show the rollup highlights
+      ansible.builtin.debug:
+        msg: "Fleet rollup written to {{ aggregate_output }}"

--- a/deploy/ansible/playbook-set-fact.yml
+++ b/deploy/ansible/playbook-set-fact.yml
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run pqc-readiness against every host in the `pqc_targets` group, set
+# the resulting facts under `pqc_readiness`, and print the verdict for
+# each host.  Use this as the starting template for any
+# `pqc_readiness`-aware play.
+#
+# Why two tasks (run, then set_fact): the script's `--ansible` flag
+# emits `{ansible_facts: {pqc_readiness: ...}}`, which Ansible can pick
+# up directly when used as a module-style fact source.  The `script`
+# module returns stdout in `register`, so we json-decode that and feed
+# it through `set_fact` ourselves.  The two-step form is portable
+# across `ansible-core` versions and works on hosts where the controller
+# Python differs from the target Python.
+#
+# `become: false` is the default — the probe runs fine without root.
+# Set `become_for_tpm: true` (vars below) to escalate just for the probe
+# task; that fills in `tpm_pqc.pqc_advertised` (TPM 2.0 query needs
+# /dev/tpmrm0 access).  See docs/ansible.md for the full privilege
+# requirements list.
+#
+# Validated against `ansible-core 2.20.5`.
+---
+- name: Probe PQC readiness across the fleet and capture facts
+  hosts: pqc_targets
+  gather_facts: false
+  vars:
+    # Set true to run the probe under become — the only field this
+    # actually changes today is tpm_pqc.pqc_advertised.
+    become_for_tpm: false
+  tasks:
+    - name: Run pqc-readiness with --ansible
+      ansible.builtin.script:
+        cmd: ../../pqc_readiness.py --ansible
+      register: pqc_raw
+      changed_when: false
+      become: "{{ become_for_tpm }}"
+
+    - name: Set pqc_readiness facts from probe output
+      ansible.builtin.set_fact:
+        pqc_readiness: "{{ (pqc_raw.stdout | from_json).ansible_facts.pqc_readiness }}"
+
+    - name: Print the verdict for each host
+      ansible.builtin.debug:
+        msg: >-
+          {{ inventory_hostname }}: {{ pqc_readiness.verdict }}
+          (isa_tier={{ pqc_readiness.isa_tier }},
+          openssl.pqc_native={{ pqc_readiness.openssl.pqc_native }},
+          replace_required={{ pqc_readiness.replace_required }})

--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -1,0 +1,244 @@
+# Running pqc-readiness from Ansible
+
+`pqc-readiness` ships an `--ansible` flag that wraps the standard
+[`--json`](../README.md#json-output---json) output in
+`{ansible_facts: {pqc_readiness: ...}}` and always exits 0, so the
+probe slots into a normal Ansible facts pipeline. This document is the
+runnable, copy-pasteable guide to that workflow: ad-hoc invocation,
+playbooks for `set_fact` and fleet aggregation, the privilege model,
+and the field shape downstream tasks can rely on.
+
+The example playbooks live under
+[`deploy/ansible/`](../deploy/ansible/) and have been validated
+against `ansible-core 2.20.5`.
+
+## Ad-hoc invocation
+
+The `script` module from `ansible.builtin` ships the script to each
+target and runs it. The simplest version emits the standard JSON
+schema and registers the result on the controller:
+
+```bash
+ansible all -i inventory.ini \
+  -m ansible.builtin.script \
+  -a "/path/to/pqc_readiness.py --json"
+```
+
+If your invocation form on the targets is the
+[`pqc-readiness` wrapper launcher](../README.md#quick-start) (the
+RHEL-8-safe entry point), substitute it for `pqc_readiness.py`. The
+wrapper finds the highest available Python 3.9+ on the target's PATH.
+
+For a one-shot fact harvest into the controller's variable cache,
+swap `--json` for `--ansible` and feed the result into `set_fact`:
+
+```bash
+ansible all -i inventory.ini \
+  -m ansible.builtin.script \
+  -a "/path/to/pqc_readiness.py --ansible" \
+  --tree /tmp/pqc/
+```
+
+`--tree /tmp/pqc/` writes one JSON file per host so you can inspect
+the raw output. To set the facts in-flight, use the playbook below.
+
+## Playbook: `set_fact` from `--ansible`
+
+[`deploy/ansible/playbook-set-fact.yml`](../deploy/ansible/playbook-set-fact.yml)
+runs the probe against the `pqc_targets` group, decodes the
+`--ansible` envelope, and exposes the report as the `pqc_readiness`
+host fact. A follow-up task uses the fact to print the verdict.
+
+```yaml
+- name: Probe PQC readiness across the fleet and capture facts
+  hosts: pqc_targets
+  gather_facts: false
+  tasks:
+    - name: Run pqc-readiness with --ansible
+      ansible.builtin.script:
+        cmd: ../../pqc_readiness.py --ansible
+      register: pqc_raw
+      changed_when: false
+
+    - name: Set pqc_readiness facts from probe output
+      ansible.builtin.set_fact:
+        pqc_readiness: "{{ (pqc_raw.stdout | from_json).ansible_facts.pqc_readiness }}"
+
+    - name: Print the verdict for each host
+      ansible.builtin.debug:
+        msg: >-
+          {{ inventory_hostname }}: {{ pqc_readiness.verdict }}
+          (isa_tier={{ pqc_readiness.isa_tier }},
+          openssl.pqc_native={{ pqc_readiness.openssl.pqc_native }},
+          replace_required={{ pqc_readiness.replace_required }})
+```
+
+Once `pqc_readiness` is set, downstream tasks can branch on it
+without re-running the probe. Examples:
+
+```yaml
+- name: Open a migration ticket for hosts that need accelerator help
+  ansible.builtin.debug:
+    msg: "Open ticket: {{ inventory_hostname }} requires accelerator (verdict={{ pqc_readiness.verdict }})"
+  when: pqc_readiness.replace_required
+
+- name: Flag CNSA 2.0 non-compliance
+  ansible.builtin.debug:
+    msg: "{{ inventory_hostname }} CNSA 2.0 status: {{ pqc_readiness.cnsa_2_0.status }}"
+  when: pqc_readiness.cnsa_2_0.status != 'compliant'
+```
+
+Run it:
+
+```bash
+ansible-playbook -i deploy/ansible/inventory.example.ini \
+  deploy/ansible/playbook-set-fact.yml
+```
+
+## Playbook: fleet aggregation
+
+[`deploy/ansible/playbook-fleet-aggregate.yml`](../deploy/ansible/playbook-fleet-aggregate.yml)
+runs the probe on every target, fetches the JSON to the controller,
+and runs `pqc_readiness.py --aggregate DIR` over the collection to
+produce the same fleet rollup the OpenShift DaemonSet workflow
+produces. The two phases live in the same playbook:
+
+```yaml
+- name: Phase 1 — run the probe on every target and emit JSON
+  hosts: pqc_targets
+  gather_facts: false
+  vars:
+    rollup_dir: "{{ playbook_dir }}/.rollup"
+  tasks:
+    - ansible.builtin.script: { cmd: "../../pqc_readiness.py --json" }
+      register: pqc_raw
+      changed_when: false
+    - ansible.builtin.copy:
+        content: "{{ pqc_raw.stdout }}"
+        dest: /var/tmp/pqc-readiness.json
+        mode: "0644"
+      changed_when: false
+    - ansible.builtin.fetch:
+        src: /var/tmp/pqc-readiness.json
+        dest: "{{ rollup_dir }}/{{ inventory_hostname }}.json"
+        flat: true
+
+- name: Phase 2 — controller-side aggregation
+  hosts: controller
+  gather_facts: false
+  vars:
+    rollup_dir: "{{ playbook_dir }}/.rollup"
+  tasks:
+    - ansible.builtin.shell:
+        cmd: "{{ playbook_dir }}/../../pqc_readiness.py --aggregate {{ rollup_dir }} > {{ rollup_dir }}/fleet-rollup.json"
+        changed_when: true
+```
+
+Output:
+
+- `<rollup_dir>/<hostname>.json` — one per target.
+- `<rollup_dir>/fleet-rollup.json` — counts by arch, OS, ISA tier,
+  verdict, runtime environment, accelerator kind; unique CPU model
+  list; `replace_required_count`. Same schema as
+  [README ## Aggregation](../README.md#aggregation-1).
+
+## Privilege requirements
+
+The probe does *not* need `become: yes` for the headline readiness
+signal. ISA detection, OpenSSL inspection, kernel TLS / FIPS state,
+SSH PQC kex enumeration, IPsec checks, NSS, accelerator enumeration
+via `lspci -nn`, the `/proc/crypto` and `/proc/cpuinfo` reads, and
+the trust-store scan all work as an unprivileged user on every Linux
+distribution this script targets. `--ansible` mode itself works
+without become.
+
+The one field that goes from "unknown" to populated when you escalate
+is `tpm_pqc.pqc_advertised`:
+
+| Field | Without become | With become |
+| --- | --- | --- |
+| `tpm_pqc.pqc_advertised` | absent — `tpm_pqc.note` is `"tpm2_getcap failed"` and `tpm_pqc.raw` shows `Failed to open ... /dev/tpmrm0: Permission denied` | populated boolean (almost always `false`; TPM 2.0 specs do not yet mandate PQC) |
+
+The reason is concrete: `tpm2_getcap algorithms` opens
+`/dev/tpmrm0`, which is restricted to root or members of the `tss`
+group on every modern distribution. Granting access via `tss` group
+membership is a per-host policy decision that lives outside this
+script.
+
+In practice: leave the probe at `become: false` for routine inventory
+runs. Escalate only when you specifically need TPM PQC capability data
+— the difference is one boolean. The `playbook-set-fact.yml` example
+exposes this as a `become_for_tpm` variable that defaults to `false`
+and can be flipped per run:
+
+```bash
+ansible-playbook -i inventory.ini deploy/ansible/playbook-set-fact.yml \
+  --extra-vars become_for_tpm=true
+```
+
+Other root-only paths are not exercised by the default probe. The
+script does not call `dmidecode`, does not invoke `lspci -vvv`, and
+does not require write access anywhere on the target.
+
+## Sample `ansible_facts.pqc_readiness` shape
+
+The fact tree under `pqc_readiness` mirrors the standard `--json`
+schema [documented in the README](../README.md#json-output---json).
+Downstream tasks should rely on these keys:
+
+```yaml
+pqc_readiness:
+  verdict: "EXCELLENT - software PQC at production speed"
+  isa_tier: "excellent"
+  replace_required: false
+  openssl:
+    version: "OpenSSL 3.5.5 27 Jan 2026 (Library: OpenSSL 3.5.5 27 Jan 2026)"
+    pqc_native: true
+  tpm_pqc:
+    present: true
+    tools: true
+    note: "tpm2_getcap failed"          # without become; pqc_advertised: false with become
+  cnsa_2_0:
+    status: "partial"                    # or "compliant" / "non-compliant"
+    kem_compliant: true
+    signature_compliant: true
+  schema_version: "1.0"
+```
+
+The full key list is stable across `schema_version: "1.0"`. Top-level
+keys that consumers most often branch on:
+
+- `verdict` — coarse one-liner.
+- `isa_tier` — one of `excellent` / `good` / `marginal` / `poor`.
+- `replace_required` — boolean for fleet planning.
+- `openssl.pqc_native` — whether the host's OpenSSL ≥ 3.5 PQC
+  primitives are available.
+- `cnsa_2_0.status` — `compliant` / `partial` / `non-compliant`.
+- `exit_code` — the exit code the probe would return outside the
+  `--ansible` wrapper, for compatibility with `--check TIER`.
+
+## Versions validated
+
+The example playbooks were validated with:
+
+```text
+ansible-playbook --syntax-check
+ansible-core 2.20.5
+```
+
+Either run `ansible --version` to confirm parity with your runtime,
+or update the version in this section if you adapt the playbooks for
+an older `ansible-core` build.
+
+## Out of scope
+
+This document and the example playbooks deliberately do not cover:
+
+- A full Ansible Collection or Galaxy role — the `script` module is
+  enough for the use case.
+- AAP / Automation Controller / Tower job template definitions.
+- Custom inventory plugins.
+- `ansible-lint` integration in CI.
+
+If a customer engagement needs any of those, file a separate issue —
+each is a multi-day deliverable on its own.


### PR DESCRIPTION
## Summary

- `docs/ansible.md` covers ad-hoc invocation, a `set_fact` playbook, a fleet-aggregation playbook, the privilege model, and the `ansible_facts.pqc_readiness` shape downstream tasks can rely on.
- `deploy/ansible/` ships three runnable assets referenced from the doc: `playbook-set-fact.yml`, `playbook-fleet-aggregate.yml`, and `inventory.example.ini`. Both playbooks pass `ansible-playbook --syntax-check` against `ansible-core 2.20.5`.
- README's `--ansible` row, the JSON-output `--ansible` paragraph, and the Documentation map cross-link the new doc. CONTRIBUTING.md's "README is part of the feature" rule is extended to cover Ansible-affecting changes.

## Acceptance criteria (from #31)

- [x] `docs/ansible.md` covers ad-hoc invocation, `--ansible` + `set_fact` playbook, multi-host aggregation playbook, become / privilege requirements, and a sample output snippet.
- [x] `deploy/ansible/` directory contains `playbook-set-fact.yml`, `playbook-fleet-aggregate.yml`, `inventory.example.ini`.
- [x] Both playbooks pass `ansible-playbook --syntax-check` against `ansible-core 2.20.5` (current stable). The version is documented in `docs/ansible.md` under "Versions validated".
- [x] README cross-links `docs/ansible.md` from the `--ansible` flag row and the JSON-output paragraph; Documentation map gains a `docs/ansible.md` entry.
- [x] CONTRIBUTING.md "README is part of the feature" gains a one-liner: changes affecting `--ansible` / become model / `deploy/ansible/` keep `docs/ansible.md` and the example playbooks in sync.

## Privilege requirements — concrete diff

Verified by code inspection plus a no-become run on Fedora 44. The probe runs unprivileged for the headline readiness signal — ISA detection, OpenSSL inspection, kernel TLS / FIPS state, SSH PQC kex, IPsec, NSS, accelerator enumeration via `lspci -nn`, `/proc/crypto`, the trust-store scan, and the `--scan-packages` rpm/dpkg/pacman/apk query all work as an unprivileged user.

The single field that flips from absent to populated under `become: yes` is `tpm_pqc.pqc_advertised`. Without become, the script logs:

```
tpm_pqc.note: "tpm2_getcap failed"
tpm_pqc.raw:  "ERROR:tcti:src/tss2-tcti/tcti-device.c:455:Tss2_Tcti_Device_Init() Failed to open specified TCTI device file /dev/tpmrm0: Permission denied"
```

Reason: `tpm2_getcap algorithms` opens `/dev/tpmrm0`, restricted to root or the `tss` group on every modern distro. The doc names this exactly so customers do not over-escalate routine inventory runs. The set_fact playbook exposes the escalation as a `become_for_tpm` variable that defaults to `false`.

## Test plan

- [x] `ansible-playbook --syntax-check -i deploy/ansible/inventory.example.ini deploy/ansible/playbook-set-fact.yml` — pass.
- [x] `ansible-playbook --syntax-check -i deploy/ansible/inventory.example.ini deploy/ansible/playbook-fleet-aggregate.yml` — pass.
- [x] `python3 -m pytest tests/ -q` — 230 passed (no test changes; ran to confirm no regressions).
- [x] `ruff check pqc_readiness.py tests/` — clean.
- [x] `mypy --strict pqc_readiness.py` — clean.
- [x] `bash scripts/check-no-third-party-refs.sh` — clean.
- [x] `bash scripts/check-readme-flags.sh` — all 24 `--help` flags covered.

## CodeRabbit review

`cr --plain --type uncommitted` flagged that Phase 1 of `playbook-fleet-aggregate.yml` referenced `hostvars['localhost'].rollup_dir`, which is undefined when Phase 1 runs (the controller play has not yet executed). Fixed by declaring `rollup_dir` in both phases' `vars:` blocks from `playbook_dir`, which resolves identically across host contexts. Also dropped a stale `creates:` guard on the aggregator shell task — the fleet rollup is meant to regenerate on every run. Subsequent `cr` invocations hit the org hourly cap before reporting; PR-side CodeRabbit will run on this PR.

## Out of scope (per issue body)

- Full Ansible Collection / Galaxy role.
- AAP / Automation Controller / Tower job templates.
- Custom inventory plugins.
- `ansible-lint` in CI.
- Changes to the `--ansible` output shape itself.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)