### PR TITLE
feat(ci): add UBI 8 container build and CI validation (closes #30)

### DIFF
--- a/.github/workflows/ci-ubi8.yml
+++ b/.github/workflows/ci-ubi8.yml
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+# CI: build the UBI 8 runtime image and run the pytest suite inside an
+# extension image under the AppStream `python3.9` interpreter.
+#
+# Why a separate workflow: the existing ci.yml uses `actions/setup-python`
+# on `ubuntu-latest` to cover the 3.11 / 3.12 / 3.13 matrix.  UBI 8 ships
+# Python 3.9 from the AppStream `python39` module — that combination is
+# not expressible via setup-python on Ubuntu, and validating it requires
+# running inside an actual UBI 8 image.  Keeping it in its own workflow
+# leaves the Ubuntu-matrix logic in ci.yml clean.
+#
+# Why an extension image instead of bind-mounting the workspace into
+# the runtime image: microdnf and rootless-podman bind mounts interact
+# badly across cwd / SELinux contexts.  Building a separate test image
+# that COPYs tests/ + the script keeps the runtime image lean (no
+# pytest, no test fixtures shipped to customers) and the CI step
+# reproducible — the same `podman build` / `podman run` pair works
+# locally and in CI.
+#
+# Action versions verified against upstream releases at the time of
+# writing (per CLAUDE.md "Always verify current versions before using
+# them").  Bump deliberately and re-verify, not via Dependabot churn:
+#   actions/checkout@v6.0.2  (gh api repos/actions/checkout/releases/latest)
+
+name: ci-ubi8
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    name: build + test (UBI 8 / python3.9)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Build the UBI 8 runtime image
+        # podman is preinstalled on ubuntu-latest runners; the same
+        # `make container-ubi8` target reproduces this locally.
+        run: |
+          podman build --format=docker \
+            -t pqc-readiness:ubi8 \
+            -f Containerfile.ubi8 .
+
+      - name: Smoke-test the wrapper launcher
+        # --help is the cheapest path through the wrapper + script and
+        # exits 0 on success.  If python3.9 is missing inside the image
+        # or the wrapper cannot find it, this step fails before pytest
+        # so the failure is unambiguous.
+        run: |
+          podman run --rm pqc-readiness:ubi8 --help >/dev/null
+
+      - name: Build the test extension image
+        # Layers test-only dependencies (python39-pip, pytest,
+        # jsonschema, referencing, git) on top of the runtime image and
+        # COPYs tests/ + the script + the wrapper into a working dir.
+        # Customers never ship this image — it exists only inside CI to
+        # validate that the runtime image's Python 3.9 environment can
+        # run every test in the suite.
+        run: |
+          cat <<'CONTAINERFILE' | podman build --format=docker -t pqc-readiness:ubi8-test -f - .
+          FROM pqc-readiness:ubi8
+          USER 0
+          WORKDIR /tmp/build
+          RUN microdnf install -y --nodocs --setopt=install_weak_deps=0 \
+                  python39-pip \
+                  git \
+              && microdnf clean all
+          RUN python3.9 -m pip install --no-cache-dir \
+                  pytest \
+                  jsonschema \
+                  referencing
+          COPY tests/             /tmp/build/tests/
+          COPY pqc_readiness.py   /tmp/build/pqc_readiness.py
+          COPY pqc-readiness      /tmp/build/pqc-readiness
+          RUN chmod 0755 /tmp/build/pqc-readiness /tmp/build/pqc_readiness.py
+          CONTAINERFILE
+
+      - name: Run pytest under python3.9 inside the test image
+        run: |
+          podman run --rm \
+            --user 0 \
+            --entrypoint /bin/sh \
+            pqc-readiness:ubi8-test \
+            -c 'cd /tmp/build && python3.9 -m pytest tests/ -q'

--- a/Containerfile.ubi8
+++ b/Containerfile.ubi8
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+# Containerfile.ubi8 — host-level Post-Quantum Cryptography readiness
+# assessment, Red Hat UBI 8 minimal base.  Companion to
+# Containerfile.ubi10 (current Red Hat path) and Containerfile.debian
+# (Debian/Ubuntu path); ships so RHEL 8 / Rocky 8 / AlmaLinux 8 fleets
+# can deploy a ready-to-run image without first enabling the AppStream
+# `python39` module on every host.
+#
+# Build:
+#   podman build --format=docker -t pqc-readiness:ubi8 -f Containerfile.ubi8 .
+#
+# Run (host probe — same shape as the UBI 10 image):
+#   podman run --rm \
+#     --pid=host \
+#     -v /proc:/host/proc:ro \
+#     -v /sys:/host/sys:ro \
+#     -v /dev:/host/dev:ro \
+#     -v /etc:/host/etc:ro \
+#     -v /usr/lib/os-release:/host/usr/lib/os-release:ro \
+#     pqc-readiness:ubi8 --host-mount /host --json
+#
+# UBI 8.10 is the current released minor at the time of writing.  Verify
+# before bumping:
+#   curl -s https://registry.access.redhat.com/v2/ubi8/ubi-minimal/tags/list \
+#     | jq '.tags | map(select(test("^8\\.")))'
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10
+
+LABEL org.opencontainers.image.title="pqc-readiness"
+LABEL org.opencontainers.image.description="Host-level PQC readiness assessment (UBI 8)"
+LABEL org.opencontainers.image.source="https://github.com/aclater/pqc-readiness"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.vendor="Red Hat (community)"
+
+# UBI 8 ships Python 3.6 as `python3` by default; the script needs
+# 3.9+ for PEP 604 union syntax and builtin generics.  The AppStream
+# `python39` module is part of UBI 8's package set and provides the
+# `python3.9` interpreter alongside the system python3 — installing it
+# does not displace `/usr/bin/python3` (still 3.6), it adds
+# `/usr/bin/python3.9`.  The wrapper launcher (see /usr/local/bin/
+# pqc-readiness below) already searches PATH for `python3.9` ahead of
+# the system `python3`, so no extra wiring is needed.
+#
+# python39-numpy is the AppStream-supplied numpy build matched to
+# python3.9 — required for the STREAM-triad memory-bandwidth probe;
+# the script falls back gracefully when missing, but every customer
+# report should have a real bandwidth number.
+RUN microdnf install -y --nodocs --setopt=install_weak_deps=0 \
+        python39 \
+        python39-numpy \
+        openssl \
+        openssh-clients \
+    && microdnf clean all \
+    && rm -rf /var/cache/yum
+
+# Non-root UID 1001 — required by OpenShift restricted SCC and matches
+# the convention in CLAUDE.md.  The probe never writes inside the
+# image; outputs are emitted to stdout or a bind-mounted volume.
+RUN useradd -r -u 1001 -g 0 -s /sbin/nologin -d /var/lib/pqc-readiness probe \
+    && mkdir -p /var/lib/pqc-readiness \
+    && chown -R 1001:0 /var/lib/pqc-readiness \
+    && chmod -R g+rwX /var/lib/pqc-readiness
+
+# Two files: the Python script and the shell wrapper that locates a
+# usable interpreter before exec'ing it.  On UBI 8 the wrapper finds
+# `python3.9` (installed above); on UBI 10 / Debian 12 the same wrapper
+# finds the system `python3` directly.  Same invocation form across
+# all three images.
+COPY --chown=1001:0 pqc_readiness.py /usr/local/bin/pqc_readiness.py
+COPY --chown=1001:0 pqc-readiness    /usr/local/bin/pqc-readiness
+RUN chmod 0755 /usr/local/bin/pqc_readiness.py /usr/local/bin/pqc-readiness
+
+# Healthcheck: verify the script imports + executes (--help is cheap
+# and always exits 0).  ubi8-minimal does not ship curl, so we use
+# python3.9 directly against the .py to keep the healthcheck
+# independent of the wrapper's PATH search.
+HEALTHCHECK --interval=1h --timeout=5s --start-period=5s --retries=1 \
+    CMD python3.9 /usr/local/bin/pqc_readiness.py --help >/dev/null 2>&1 || exit 1
+
+USER 1001
+WORKDIR /var/lib/pqc-readiness
+
+ENTRYPOINT ["/usr/local/bin/pqc-readiness"]
+CMD ["--json"]

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,11 @@ RUFF ?= ruff
 MYPY ?= mypy
 PODMAN ?= podman
 IMAGE ?= pqc-readiness:dev
+IMAGE_UBI8 ?= pqc-readiness:ubi8
 IMAGE_UBI10 ?= pqc-readiness:ubi10
 IMAGE_DEBIAN ?= pqc-readiness:debian
 
-.PHONY: help test lint typecheck check check-readme container container-build container-ubi10 container-debian clean
+.PHONY: help test lint typecheck check check-readme container container-build container-ubi8 container-ubi10 container-debian clean
 
 help:
 	@grep -E '^[a-zA-Z_-]+:.*##' Makefile | awk -F':.*##' '{printf "  %-20s %s\n", $$1, $$2}'
@@ -31,7 +32,10 @@ check-readme: ## Verify README.md documents every --help flag
 
 container-build: container-ubi10 ## Alias for container-ubi10 (back-compat)
 
-container: container-ubi10 container-debian ## Build both UBI and Debian images
+container: container-ubi8 container-ubi10 container-debian ## Build all three container images
+
+container-ubi8: ## Build the UBI 8 minimal container (RHEL 8 / Rocky 8 / AlmaLinux 8) with podman
+	$(PODMAN) build --format=docker -t $(IMAGE_UBI8) -f Containerfile.ubi8 .
 
 container-ubi10: ## Build the UBI 10 minimal container with podman
 	$(PODMAN) build --format=docker -t $(IMAGE_UBI10) -f Containerfile.ubi10 .

--- a/README.md
+++ b/README.md
@@ -290,9 +290,20 @@ schema matches in CI or in maintainer testing.
 | Tier | Distros | Validation cadence |
 | --- | --- | --- |
 | **1** | RHEL 9, RHEL 10, Ubuntu 24.04 LTS, Debian 12 | Every change (CI) |
-| **2** | Fedora (latest), Rocky / AlmaLinux 9 and 10, Ubuntu 25.10, Debian 13, SLES 15 SP6+ | Periodic (weekly) — fixes accepted |
-| **3** | RHEL 8, Rocky 8, AlmaLinux 8 | Best-effort, community-supported. Requires the AppStream `python39` (or higher) module — invoke via the `pqc-readiness` wrapper. OpenSSL 1.1.1 means `openssl.pqc_native: false` and a no-bench caveat; the inventory probe still works. |
+| **2** | Fedora (latest), Rocky / AlmaLinux 9 and 10, Ubuntu 25.10, Debian 13, SLES 15 SP6+, RHEL 8, Rocky 8, AlmaLinux 8 | Periodic (weekly) — fixes accepted |
 | **3** | Arch, Alpine, others | Best-effort, community-supported |
+
+**RHEL 8 / Rocky 8 / AlmaLinux 8 specifics.** The system `python3` on
+EL8 is 3.6, which cannot parse the script. Install the AppStream
+`python39` (or `python311`) module and invoke through the
+`pqc-readiness` wrapper, which finds the right interpreter
+automatically. OpenSSL 1.1.1 on EL8 means `openssl.pqc_native: false`
+and a no-bench caveat in the verdict; the inventory probe still
+works. A ready-to-deploy image is shipped at
+[`Containerfile.ubi8`](Containerfile.ubi8) (build via
+`make container-ubi8`); the existing `--host-mount` DaemonSet pattern
+works the same way as the UBI 10 image. CI validates every push
+against the UBI 8 image so regressions surface before a release.
 
 `detect_os()` resolves `family` from `/etc/os-release` `ID` and falls
 back through `ID_LIKE`, so derivatives the explicit table doesn’t name
@@ -313,10 +324,14 @@ already in the script.
 
 ## Container / OpenShift
 
-Two Containerfiles are provided:
+Containerfiles are provided for the supported base images:
 
 - `Containerfile.ubi10` — Red Hat UBI 10 minimal base. Default for
   RHEL/Fedora fleets and the image referenced by the systemd quadlet.
+- `Containerfile.ubi8` — Red Hat UBI 8 minimal base for RHEL 8 /
+  Rocky 8 / AlmaLinux 8 fleets that cannot move to UBI 10. Pulls the
+  AppStream `python39` module; same wrapper, same flags, same JSON
+  schema as the other images.
 - `Containerfile.debian` — `debian:12-slim` base. Functionally
   identical (same script, flags, JSON schema, UID 1001, healthcheck).
   Use for Debian/Ubuntu fleets.
@@ -324,9 +339,10 @@ Two Containerfiles are provided:
   customer ask.
 
 ```bash
-make container-ubi10     # build the UBI image
+make container-ubi8      # build the UBI 8 image
+make container-ubi10     # build the UBI 10 image
 make container-debian    # build the Debian image
-make container           # build both
+make container           # build all three
 ```
 
 `deploy/quadlet/pqc-readiness.container` is a systemd quadlet that runs


### PR DESCRIPTION
## Summary

- New \`Containerfile.ubi8\` mirroring the existing \`Containerfile.ubi10\` patterns: \`registry.access.redhat.com/ubi8/ubi-minimal:8.10\`, AppStream \`python39\` + \`python39-numpy\` + openssl + openssh-clients, UID 1001 + group 0, Python-only HEALTHCHECK via \`python3.9\`, wrapper launcher (#29) as ENTRYPOINT.
- New \`make container-ubi8\` Makefile target; \`make container\` now builds all three images.
- New \`.github/workflows/ci-ubi8.yml\` — builds the runtime image, smoke-tests the wrapper, then layers a small extension image with pytest + jsonschema + referencing on top and runs the full suite under \`python3.9\`. Existing \`ci.yml\` matrix on \`ubuntu-latest\` is unchanged.
- README support-matrix promotes RHEL 8 / Rocky 8 / AlmaLinux 8 from Tier 3 to Tier 2 in the same PR. EL8-specific notes (AppStream module, OpenSSL 1.1.1 caveat, DaemonSet pattern) moved to a dedicated paragraph below the table; the Containers section gains the \`Containerfile.ubi8\` entry.

## Acceptance criteria (issue #30)

- [x] New \`Containerfile.ubi8\` based on \`registry.access.redhat.com/ubi8/ubi-minimal:8.10\` (8.10 verified via the registry tags API)
- [x] \`microdnf install\` python39 + python39-pip equivalents + numpy + openssl + openssh-clients
- [x] Non-root UID 1001
- [x] Python-only HEALTHCHECK (no curl on minimal)
- [x] Wrapper launcher from #29 as ENTRYPOINT
- [x] Matches \`Containerfile.ubi10\` / \`Containerfile.debian\` build hygiene
- [x] Verified image build: \`make container-ubi8\` builds locally; the resulting container produces valid \`--help\`, \`--version\`, and \`--json\` output
- [x] New CI job runs the existing pytest suite inside the UBI 8 image (chose top-level \`ci-ubi8.yml\` workflow per the issue's two-shape suggestion)
- [x] Existing CI matrix (Python 3.11 / 3.12 / 3.13 on \`ubuntu-latest\`) unchanged
- [x] README support-matrix bumped (RHEL 8 / Rocky 8 / AlmaLinux 8 → Tier 2)
- [x] Makefile \`container-ubi8\` target added; \`container\` builds all three

## Design choice — extension image vs bind-mount

I tried the bind-mount approach first (mount the repo at \`/work\`, install pip + pytest at \`podman run\` time, run pytest against the live source). It hit two problems even on a developer host with rootless podman: (a) microdnf failed transactions when cwd was the bind-mounted workspace, and (b) SELinux uid mapping denied root inside the container from reading the host-owned mount.

The extension-image approach (small \`FROM pqc-readiness:ubi8\` Containerfile that adds pytest + tests/) is reproducible identically locally and in CI. The runtime image stays lean — customers don't ship pytest or fixtures.

## Test plan

- [x] \`pytest -q\` on the host — 242 passed (existing matrix unchanged)
- [x] \`scripts/check-no-third-party-refs.sh\` — clean
- [x] \`scripts/check-readme-flags.sh\` — clean (24/24 flags documented)
- [x] \`make container-ubi8\` builds the image (verified locally, ~73 MB)
- [x] \`podman run --rm pqc-readiness:ubi8 --help\` exits 0 (wrapper finds \`/usr/bin/python3.9\`)
- [x] Full pytest suite passes inside the extension image: **240 passed, 2 skipped** under \`python3.9\` (the 2 skips are platform-conditional, also skipped on the existing 3.11/3.12/3.13 matrix)

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)