### PR TITLE
fix(launcher): sh/Python polyglot shebang on .py for EL8 (#36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ DaemonSet on OpenShift.
 
 ```bash
 ./pqc-readiness                       # recommended: shell wrapper picks a usable Python
-./pqc_readiness.py                    # equivalent on hosts whose default `python3` is 3.9+
+./pqc_readiness.py                    # equivalent — the .py carries the same polyglot probe
 ./pqc-readiness --bench               # include OpenSSL microbench
 ./pqc-readiness --json                # stable JSON for aggregation
 ./pqc-readiness --cbom                # CycloneDX 1.6 CBOM JSON (NIST IR 8547)
@@ -55,12 +55,16 @@ DaemonSet on OpenShift.
 ./pqc-readiness --version             # script + JSON schema versions
 ```
 
-The `pqc-readiness` shell wrapper is the recommended invocation form
-because it is RHEL-8-safe: it searches `PATH` for the highest available
-Python 3.9+ (`python3.13` → `python3.9`, then `python3`, then `python`)
-and `exec`s `pqc_readiness.py` with that interpreter. On a host whose
-default `python3` is too old (RHEL 8 / Rocky 8 / AlmaLinux 8 ship 3.6),
-it prints AppStream guidance instead of a Python `SyntaxError`.
+Either entry point is RHEL-8-safe. `pqc_readiness.py` carries a
+sh/Python polyglot shebang that runs the same interpreter probe as the
+wrapper before handing off to Python: `python3.13` → `python3.9`, then
+`python3`, then `python`, with a runtime `sys.version_info` check on
+each candidate so a too-old `python3` (3.6 on stock EL8) is rejected
+rather than silently exec'd into a `SyntaxError`. On a host with no
+suitable interpreter, both forms print the same AppStream guidance and
+exit 127. The thin `pqc-readiness` wrapper is preserved for
+operational ergonomics — a hostname-style command name on `PATH` and a
+single place to extend probe order without re-touching the .py.
 
 Both files ship side by side in the container images at
 `/usr/local/bin/pqc-readiness` (wrapper) and
@@ -295,13 +299,18 @@ schema matches in CI or in maintainer testing.
 | **2** | Fedora (latest), Rocky / AlmaLinux 9 and 10, Ubuntu 25.10, Debian 13, SLES 15 SP6+, RHEL 8, Rocky 8, AlmaLinux 8 | Periodic (weekly) — fixes accepted |
 | **3** | Arch, Alpine, others | Best-effort, community-supported |
 
-**RHEL 8 / Rocky 8 / AlmaLinux 8 specifics.** The system `python3` on
-EL8 is 3.6, which cannot parse the script. Install the AppStream
-`python39` (or `python311`) module and invoke through the
-`pqc-readiness` wrapper, which finds the right interpreter
-automatically. OpenSSL 1.1.1 on EL8 means `openssl.pqc_native: false`
-and a no-bench caveat in the verdict; the inventory probe still
-works. A ready-to-deploy image is shipped at
+**RHEL 8 / Rocky 8 / AlmaLinux 8 specifics.** Stock cloud images
+(RHEL 8.10 KVM Guest, Rocky 8.10 GenericCloud, AlmaLinux 8.10
+GenericCloud) ship `platform-python` (3.6) but no `/usr/bin/python3`
+symlink at all, and the system `python3` you do get after running
+`alternatives` is still 3.6 — too old to parse the modern type-hint
+syntax this script uses. Install the AppStream `python39` (or
+`python311`) module and invoke either `./pqc_readiness.py` directly or
+through the `pqc-readiness` wrapper; both carry the same probe order
+and reject 3.6 with an actionable error referencing
+`dnf module install python39`. OpenSSL 1.1.1 on EL8 means
+`openssl.pqc_native: false` and a no-bench caveat in the verdict; the
+inventory probe still works. A ready-to-deploy image is shipped at
 [`Containerfile.ubi8`](Containerfile.ubi8) (build via
 `make container-ubi8`); the existing `--host-mount` DaemonSet pattern
 works the same way as the UBI 10 image. CI validates every push

--- a/docs/schema-alignment.md
+++ b/docs/schema-alignment.md
@@ -58,7 +58,7 @@ follow-up issue can be filed at that point with concrete justification.
 1. Captured `./pqc_readiness.py --json` against a representative host
    (Fedora 44, OpenSSL 3.5.5, OpenSSH 10.2p1, TPM 2.0 present, no
    FIPS, no IPsec, no trust-store scan, no `--bench`).
-2. Walked the `Report` dataclass (`pqc_readiness.py:377`) to enumerate
+2. Walked the `Report` dataclass (`pqc_readiness.py:422`) to enumerate
    every declared field, including those that are empty by default in
    the captured shape (`benchmark`, `benchmark_tls_handshake`,
    `trust_store`, `packages`, `per_algo`, `production_estimate`,

--- a/pqc_readiness.py
+++ b/pqc_readiness.py
@@ -1,6 +1,54 @@
-#!/usr/bin/env python3
+#!/bin/sh
+"true" '''\'
+# Polyglot launcher: this file is a valid /bin/sh script *and* a valid
+# Python module.  When invoked directly (`./pqc_readiness.py ...`) the
+# shell side runs first, picks the highest available Python 3.9+ on
+# PATH, and `exec`s the script under it.  Python then re-reads the
+# file and treats the shell block as a discarded triple-quoted string
+# expression — `__doc__` is rebound to the real docstring immediately
+# below so `--help` / argparse keep working unchanged.
+#
+# Why this exists: RHEL 8 / Rocky Linux 8 / AlmaLinux 8 cloud images
+# ship `platform-python` (Python 3.6) but no `/usr/bin/python3`
+# symlink, so `#!/usr/bin/env python3` aborts with exit 127 before the
+# script can even introspect the host.  This polyglot mirrors the
+# `pqc-readiness` shell wrapper: same probe order, same AppStream
+# guidance on failure.  See issue aclater/pqc-readiness#36.
+#
+# The shell side runs only at first invocation; once exec replaces
+# the process with Python, this entire block (line 2 through the
+# matching closing-quote line) is parsed as one triple-quoted string
+# literal expression and discarded.
+for c in python3.13 python3.12 python3.11 python3.10 python3.9 python3 python ; do
+    command -v "$c" >/dev/null 2>&1 || continue
+    v=$("$c" -c "import sys; print(\"%d.%d\" % sys.version_info[:2])" 2>/dev/null) || continue
+    maj=${v%%.*} ; min=${v#*.}
+    [ "$maj" = 3 ] && [ "$min" -ge 9 ] 2>/dev/null && exec "$c" "$0" "$@"
+done
+cat >&2 <<'MSG'
+pqc-readiness: no Python 3.9+ interpreter found on PATH.
+
+This script requires Python 3.9 or newer.  On RHEL 8, Rocky Linux 8,
+or AlmaLinux 8 the default python3 is 3.6 (or absent on cloud images),
+which cannot parse the modern type-hint syntax this script uses.
+Enable the AppStream python39 (or higher) module:
+
+    dnf module install python39
+    /path/to/pqc_readiness.py [flags]
+
+Or invoke any 3.9+ interpreter directly:
+
+    python3.9 /path/to/pqc_readiness.py [flags]
+MSG
+exit 127
+'''
 # SPDX-License-Identifier: Apache-2.0
-"""pqc-readiness: assess host suitability for Post-Quantum Cryptography.
+from __future__ import annotations
+
+# Re-bind __doc__ now that the polyglot launcher above has consumed the
+# first string-literal slot.  Argparse reads description=__doc__ later,
+# so this assignment is what surfaces through `--help`.
+__doc__ = """pqc-readiness: assess host suitability for Post-Quantum Cryptography.
 
 Determines whether on-chip ISA features accelerate NIST PQC primitives
 (ML-KEM / Kyber, ML-DSA / Dilithium, SLH-DSA / SPHINCS+), enumerates
@@ -38,8 +86,6 @@ Exit codes:
     3  Poor       - software-only and too slow for production
     4  --check threshold not met (TIER below floor, or cnsa-2.0 not compliant)
 """
-
-from __future__ import annotations
 
 import argparse
 import json

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -12,6 +12,15 @@ launcher promises:
    guidance message.
 3. Only-too-old python3 on PATH — same AppStream guidance, distinct
    exit code from "no python at all".
+
+The second half of the file covers the *polyglot shebang* baked into
+``pqc_readiness.py`` itself (issue #36).  EL8 cloud images ship no
+``/usr/bin/python3`` symlink, so users who invoke the .py directly
+(rather than through the ``pqc-readiness`` wrapper) used to get
+``/usr/bin/env: 'python3': No such file or directory`` and exit 127
+before the script could even run.  The polyglot replicates the
+wrapper's interpreter probe inline, so direct invocation now gets the
+same AppStream guidance instead of a cryptic env(1) error.
 """
 from __future__ import annotations
 
@@ -25,6 +34,7 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 LAUNCHER = REPO_ROOT / "pqc-readiness"
+SCRIPT = REPO_ROOT / "pqc_readiness.py"
 
 
 @pytest.fixture(scope="module")
@@ -137,3 +147,154 @@ def test_launcher_passes_args_through(launcher_executable: Path) -> None:
     assert proc.returncode in (0, 1, 2, 3), proc.stderr
     assert proc.stdout.strip(), "expected a verdict line on stdout"
     assert proc.stdout.count("\n") <= 1, "--quiet should be one line"
+
+
+# ---------------------------------------------------------------------------
+# Polyglot shebang on pqc_readiness.py itself (issue #36).
+#
+# The .py file's shebang is `#!/bin/sh` followed by a sh/Python polyglot
+# block that probes for a usable interpreter and execs the script under
+# it.  This makes direct invocation safe on EL8 cloud images that ship
+# no /usr/bin/python3 symlink — the regression we're guarding against
+# is the original `env: 'python3': No such file or directory` exit 127.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def script_executable() -> Path:
+    """The .py script must be present and executable so the polyglot
+    shebang fires on direct invocation.  A non-executable file would
+    force callers through `python3 pqc_readiness.py`, defeating the
+    purpose of the polyglot."""
+    assert SCRIPT.exists(), f"script missing at {SCRIPT}"
+    assert os.access(SCRIPT, os.X_OK), f"script not executable: {SCRIPT}"
+    return SCRIPT
+
+
+def test_polyglot_shebang_is_sh_not_env_python3() -> None:
+    """The shebang must be `#!/bin/sh` so EL8 cloud images (which lack a
+    /usr/bin/python3 symlink) can run the polyglot interpreter probe.
+
+    Regression for #36: prior to the polyglot, the shebang was
+    `#!/usr/bin/env python3` and aborted with exit 127 before any
+    Python code ran.  This test pins the shebang in a way that
+    `env python3` cannot pass."""
+    first_line = SCRIPT.read_text(encoding="utf-8").splitlines()[0]
+    assert first_line == "#!/bin/sh", (
+        f"expected `#!/bin/sh` polyglot shebang, got: {first_line!r}.  "
+        "Reverting to `#!/usr/bin/env python3` reintroduces the EL8 "
+        "exit-127 regression tracked in issue #36."
+    )
+
+
+def test_polyglot_runs_under_current_python(script_executable: Path) -> None:
+    """Happy path: the developer's Python is 3.9+, the polyglot finds
+    it, and `--version` returns the schema version line.  Mirrors the
+    wrapper's happy-path test against the .py directly."""
+    proc = subprocess.run(
+        [str(script_executable), "--version"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "pqc-readiness" in proc.stdout
+    assert "schema" in proc.stdout
+
+
+def test_polyglot_no_python_on_path_emits_appstream_guidance(
+    script_executable: Path, utils_path: str
+) -> None:
+    """EL8 cloud-image reproducer: no Python interpreter on PATH at
+    all.  Direct invocation `./pqc_readiness.py` must exit 127 with
+    the AppStream guidance — the same actionable message the wrapper
+    emits — instead of `env: 'python3': No such file or directory`.
+
+    This is the core regression from #36: distro-matrix runs against
+    fresh RHEL/Rocky/Alma 8 cloud qcow2s saw exit 127 with no JSON
+    output before this fix."""
+    proc = subprocess.run(
+        [str(script_executable)],
+        capture_output=True,
+        text=True,
+        env={"PATH": utils_path},
+        check=False,
+    )
+    assert proc.returncode == 127, proc.stderr
+    assert "AppStream" in proc.stderr
+    assert "python39" in proc.stderr
+    assert "dnf module install" in proc.stderr
+    # Negative assertion: confirm the failure is *not* the env(1) error
+    # that motivated this fix.  If the polyglot ever silently regresses
+    # to `#!/usr/bin/env python3`, env's message would leak through here.
+    assert "/usr/bin/env" not in proc.stderr
+    assert "No such file or directory" not in proc.stderr
+
+
+def test_polyglot_only_old_python_emits_appstream_guidance(
+    script_executable: Path, utils_path: str, tmp_path: Path
+) -> None:
+    """RHEL 8 reality with the AppStream module *not* installed: a
+    too-old `python3` (3.6) is on PATH.  The polyglot must reject it
+    via the version probe and emit the AppStream guidance, not silently
+    fall through to a Python `SyntaxError` on modern type-hint syntax."""
+    fake_py_dir = tmp_path / "fake-py-script"
+    fake_py_dir.mkdir()
+    fake_py = fake_py_dir / "python3"
+    # Pretend to be Python 3.6 — print "3.6" on the version probe and
+    # exit 0 on anything else so the polyglot doesn't fall through to a
+    # different error path.
+    fake_py.write_text(
+        "#!/bin/sh\n"
+        "case \"$1\" in\n"
+        "  -c) echo 3.6 ;;\n"
+        "esac\n"
+        "exit 0\n"
+    )
+    fake_py.chmod(0o755)
+
+    proc = subprocess.run(
+        [str(script_executable)],
+        capture_output=True,
+        text=True,
+        env={"PATH": f"{fake_py_dir}:{utils_path}"},
+        check=False,
+    )
+    assert proc.returncode == 127, (
+        f"polyglot accepted Python 3.6 instead of rejecting it: {proc!r}"
+    )
+    assert "AppStream" in proc.stderr
+    assert "python39" in proc.stderr
+
+
+def test_polyglot_passes_args_through(script_executable: Path) -> None:
+    """Args after the program name flow into the underlying Python
+    script unchanged.  Confirms the polyglot's `exec "$c" "$0" "$@"`
+    line does not eat or reorder positional arguments."""
+    proc = subprocess.run(
+        [str(script_executable), "--quiet"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode in (0, 1, 2, 3), proc.stderr
+    assert proc.stdout.strip(), "expected a verdict line on stdout"
+    assert proc.stdout.count("\n") <= 1, "--quiet should be one line"
+
+
+def test_polyglot_module_doc_preserved(script_executable: Path) -> None:
+    """The polyglot must not corrupt `__doc__` — argparse uses it as
+    the `--help` description.  `--help` includes the docstring's
+    leading sentence, so we assert that fragment is reachable through
+    a real CLI invocation rather than poking at module internals."""
+    proc = subprocess.run(
+        [str(script_executable), "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert (
+        "assess host suitability for Post-Quantum Cryptography"
+        in proc.stdout
+    ), "module docstring not surfaced through argparse --help"


### PR DESCRIPTION
## Summary
- Replaces `#!/usr/bin/env python3` on `pqc_readiness.py` with a sh/Python polyglot shebang that mirrors the existing `pqc-readiness` wrapper's interpreter probe, so direct invocation `./pqc_readiness.py` is now EL8-cloud-image safe (no `/usr/bin/python3` symlink → no exit-127 `env` failure).
- Probes `python3.13` → `python3.9`, then `python3` / `python`, runs a `sys.version_info` check on each candidate so a too-old `python3` (3.6 on stock EL8) is rejected with the same AppStream `dnf module install python39` guidance the wrapper emits, instead of silently `exec`'ing into a `from __future__ import annotations` `SyntaxError`.
- Python side parses the shell block as a discarded triple-quoted string expression and rebinds `__doc__` to the original docstring so argparse `--help` continues to render the full usage block.
- Adds six regression tests in `tests/test_launcher.py` (separate from the existing wrapper tests) covering shebang pin, happy path, stripped-PATH EL8 reproducer, too-old-python rejection, arg passthrough after `exec`, and `__doc__` preservation through `--help`.
- README quick-start and EL8 specifics section updated to describe the new dual-entry symmetry; `docs/schema-alignment.md` line reference bumped to track the 45-line polyglot prologue.

## Test plan
- [x] `python3 -m pytest tests/ -q` → 248 passed (was 242; +6 polyglot regression tests)
- [x] Confirmed the new tests fail on the unfixed shebang (3 failures) and pass on the fix (10/10 in `test_launcher.py`)
- [x] `ruff check pqc_readiness.py tests/` → All checks passed
- [x] `mypy --strict pqc_readiness.py` → Success: no issues
- [x] `bash scripts/check-readme-flags.sh` → every `--help` flag (24) appears in README
- [x] `cr --plain --type uncommitted` → No findings
- [x] Manual EL8 reproducer with stripped `PATH` → exits 127 with AppStream guidance, not `env: 'python3': No such file or directory`
- [x] Manual reproducer with fake `python3` reporting 3.6 → rejected with AppStream guidance, not silently exec'd into a SyntaxError

## Notes for review
- The polyglot pattern is `"true" '''\<shell>'''` adjacent-string concat, chosen so the shebang line itself stays at line 1 (kernel binfmt requirement) and line 2 is benign in both languages — `true \` to sh, the start of a triple-quoted string to Python. We considered the simpler `''''<sh># '''` one-liner but the multi-line form fits the existing wrapper's interpreter probe verbatim, so the fallback message and probe order can be kept in lockstep with `pqc-readiness` without one-liner contortions.
- `__doc__` is rebound on a separate line after `from __future__ import annotations` because the polyglot string is the file's first string-literal expression and Python promotes it to the module docstring; the rebind is what surfaces through argparse `--help`. CI's existing `scripts/check-readme-flags.sh` covers this.

Closes #36