### PR TITLE
fix(verdict): align ISA tier vocabulary with --check choices (closes #39)

### DIFF
--- a/pqc_readiness.py
+++ b/pqc_readiness.py
@@ -362,7 +362,6 @@ class C:
 TIER_COLOR = {
     "excellent": C.GREEN,
     "good": C.GREEN,
-    "adequate": C.YELLOW,
     "marginal": C.YELLOW,
     "poor": C.RED,
     "unknown": C.DIM,
@@ -643,7 +642,7 @@ def isa_tier(arch: str, score: int, flags: set[str]) -> tuple[str, str]:
                 "AVX2 + AES-NI + PCLMULQDQ - production-capable in software",
             )
         if "avx2" in flags:
-            return ("adequate", "AVX2 only - workable but slower than peers")
+            return ("marginal", "AVX2 only - workable but slower than peers")
         return ("poor", "Pre-AVX2 x86 - software PQC will be slow")
     if arch in ("aarch64", "arm64"):
         if {"sha3", "aes"}.issubset(flags) and ("sve2" in flags or score >= 8):
@@ -658,7 +657,7 @@ def isa_tier(arch: str, score: int, flags: set[str]) -> tuple[str, str]:
             )
         if {"aes", "sha2", "pmull"}.issubset(flags):
             return ("good", "ARMv8 crypto extensions - production-capable")
-        return ("adequate", "Limited ARM crypto extensions")
+        return ("marginal", "Limited ARM crypto extensions")
     if arch == "s390x":
         if {"msa8", "msa9"}.issubset(flags):
             return (
@@ -666,7 +665,7 @@ def isa_tier(arch: str, score: int, flags: set[str]) -> tuple[str, str]:
                 "MSA8+MSA9 (z15+/z16) - on-chip SHA-3 / EdDSA, PQC accel possible",
             )
         if "msa" in flags:
-            return ("adequate", "Older z hardware without SHA-3 on-chip")
+            return ("marginal", "Older z hardware without SHA-3 on-chip")
         return ("poor", "No CPACF detected")
     return ("unknown", f"Architecture {arch} not classified")
 
@@ -680,7 +679,7 @@ def memory_tier(gb: float) -> tuple[str, str]:
     if gb >= 16:
         return ("good", f"{gb:.1f} GiB - adequate for medium production load")
     if gb >= 4:
-        return ("adequate", f"{gb:.1f} GiB - OK for low-volume or edge deployments")
+        return ("marginal", f"{gb:.1f} GiB - OK for low-volume or edge deployments")
     return ("poor", f"{gb:.1f} GiB - insufficient for production PQC services")
 
 
@@ -3354,7 +3353,6 @@ def overall_verdict(
     rank = {
         "excellent": 4,
         "good": 3,
-        "adequate": 2,
         "marginal": 2,
         "poor": 1,
         "unknown": 2,
@@ -3645,7 +3643,7 @@ def _recommend_tls_server(r: Report, policy: str) -> dict[str, Any]:
                 "'excellent'; ML-DSA-87 sign p99 latency will likely "
                 "exceed typical service SLOs"
             )
-        elif isa in ("poor", "marginal", "adequate"):
+        elif isa in ("poor", "marginal"):
             sig_reason = (
                 f"ML-DSA-65 because ISA tier is '{isa}' without a PQC "
                 "accelerator; ML-DSA-87 sign p99 latency would likely "

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -356,6 +356,82 @@ def test_isa_arm_i8mm_weight_is_two() -> None:
     assert pr.ARM_FEATURES["i8mm"][2] == 2
 
 
+# ISA tier vocabulary must match what `--check` accepts.  isa_tier()
+# previously returned "adequate" for AVX2-only x86, ARM without SHA-3,
+# and pre-MSA8 s390x — values that argparse rejected with an error.  See
+# audit issue #39.  The same vocabulary must hold for memory_tier(),
+# which contributes to the same overall verdict that --check gates on.
+_TIER_CHECK_CHOICES = {"excellent", "good", "marginal", "poor"}
+
+
+def test_isa_tier_avx2_only_x86_is_marginal_not_adequate() -> None:
+    """Regression for #39: AVX2-only x86 returned "adequate", which is
+    not a value `--check` accepts.  Must be "marginal"."""
+    flags = {"avx2"}
+    tier, _reason = pr.isa_tier("x86_64", score=4, flags=flags)
+    assert tier == "marginal"
+
+
+def test_isa_tier_arm_without_sha3_is_marginal() -> None:
+    """Regression for #39: ARM without SHA-3 / AES extensions returned
+    "adequate"; must be "marginal"."""
+    tier, _reason = pr.isa_tier("aarch64", score=0, flags=set())
+    assert tier == "marginal"
+
+
+def test_isa_tier_s390x_pre_msa8_is_marginal() -> None:
+    """Regression for #39: s390x with MSA but pre-MSA8 returned
+    "adequate"; must be "marginal"."""
+    tier, _reason = pr.isa_tier("s390x", score=0, flags={"msa"})
+    assert tier == "marginal"
+
+
+def test_memory_tier_mid_range_is_marginal() -> None:
+    """Regression for #39: 4-16 GiB memory returned "adequate"; must be
+    "marginal" so it lines up with the isa_tier vocabulary and the
+    `--check` choices."""
+    tier, _reason = pr.memory_tier(8.0)
+    assert tier == "marginal"
+
+
+def test_isa_tier_return_values_are_subset_of_check_choices() -> None:
+    """Every value isa_tier() can return for a classified architecture
+    must be accepted by `--check`.  Walk every branch of the function
+    and assert the tier is in the documented vocabulary."""
+    cases: list[tuple[str, int, set[str]]] = [
+        # x86_64
+        ("x86_64", 20, {"avx512f", "avx512vbmi", "avx512ifma"}),  # excellent
+        ("x86_64", 8, {"avx2", "aes", "pclmulqdq"}),              # good
+        ("x86_64", 4, {"avx2"}),                                  # marginal
+        ("x86_64", 0, set()),                                     # poor
+        # aarch64
+        ("aarch64", 10, {"sha3", "aes", "sve2"}),                 # excellent
+        ("aarch64", 4, {"sha3", "aes"}),                          # good
+        ("aarch64", 0, set()),                                    # marginal
+        # s390x
+        ("s390x", 0, {"msa", "msa8", "msa9"}),                    # excellent
+        ("s390x", 0, {"msa"}),                                    # marginal
+        ("s390x", 0, set()),                                      # poor
+    ]
+    for arch, score, flags in cases:
+        tier, _ = pr.isa_tier(arch, score, flags)
+        assert tier in _TIER_CHECK_CHOICES, (
+            f"isa_tier({arch!r}, {score}, {flags!r}) returned "
+            f"{tier!r}, which `--check` does not accept"
+        )
+
+
+def test_memory_tier_return_values_are_subset_of_check_choices() -> None:
+    """Every memory_tier() return value must also be in the `--check`
+    vocabulary, since it feeds the same overall verdict."""
+    for gb in (128.0, 32.0, 8.0, 1.0):
+        tier, _ = pr.memory_tier(gb)
+        assert tier in _TIER_CHECK_CHOICES, (
+            f"memory_tier({gb}) returned {tier!r}, which `--check` "
+            "does not accept"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Section 3: per-algorithm verdict notes + memory-bandwidth gating +
 # overall-verdict caveat for missing benchmark


### PR DESCRIPTION
## Summary

- `isa_tier()` returned `"adequate"` for AVX2-only x86, ARM without SHA-3/AES, and pre-MSA8 s390x. `memory_tier()` did the same for 4-16 GiB. None of those values were in the `--check` argparse choices (`excellent | good | marginal | poor | cnsa-2.0`), so `pqc-readiness --check adequate` raised an argparse error and the recommendation engine carried a dead-code branch (`elif isa in ("poor", "marginal", "adequate")`) for a value it could never see.
- Adopted approach (a) from the audit: renamed `"adequate"` → `"marginal"` in `isa_tier`, `memory_tier`, `TIER_COLOR`, the `overall_verdict` rank table, and `_recommend_one`'s defensive ISA check. README and `_TIER_ORDER` were already on the four-tier vocabulary, so no doc change was needed.
- Added regression tests for each previously broken branch plus a parametric assertion that every value `isa_tier` and `memory_tier` can emit is in the `--check` choice set.

## Test plan

- [x] `make check` (ruff + mypy --strict + pytest) — 248 passed
- [x] `cr --plain --type uncommitted` — no findings
- [x] Direct regression: `pqc-readiness --check marginal` is a valid invocation for every tier that `isa_tier`/`memory_tier` can return
- [x] Verified by grep that the only remaining `"adequate"` literal in `pqc_readiness.py` is descriptive prose inside a `memory_tier` reason string ("adequate for medium production load"), not a tier label

Closes #39