### PR TITLE
fix: emit per-feature unavailable_in_container flag (closes #38)

### DIFF
--- a/pqc_readiness.py
+++ b/pqc_readiness.py
@@ -99,6 +99,36 @@ def host_path(p: str) -> Path:
     return Path(p)
 
 
+def host_fs_unavailable_note(
+    detection_label: str, host_resources: str
+) -> dict[str, Any] | None:
+    """Return an `unavailable_in_container` annotation when running inside
+    a container without `--host-mount` for a detection whose result
+    depends on the host filesystem (any of /proc /sys /dev /etc /var/lib
+    /usr/lib) or on `lspci` / `dmidecode` whose output reflects the
+    container's view, not the host.  Returns None when the detection is
+    trustworthy: bare-metal invocation, or --host-mount in effect.
+
+    detection_label is the human-readable name of the detection (e.g.
+    "PCI accelerator detection"); host_resources names the host-fs
+    paths or commands the detection consults.  Both are surfaced verbatim
+    in the returned `reason` field so consumers can render a precise
+    "X is unavailable because Y" message."""
+    if HOST_PREFIX:
+        return None
+    env = detect_runtime_environment()
+    if env.get("environment") != "container":
+        return None
+    return {
+        "unavailable_in_container": True,
+        "reason": (
+            f"{detection_label} reads {host_resources}; running inside a "
+            f"container without --host-mount, so the result reflects the "
+            f"container's namespace, not the host."
+        ),
+    }
+
+
 # ---------------------------------------------------------------------------
 # ISA feature catalogs
 # Per-flag tuple = (display name, purpose, weight in tier scoring)
@@ -408,6 +438,15 @@ class Report:
     cnsa_2_0: dict[str, Any] = field(default_factory=dict)
     trust_store: dict[str, Any] = field(default_factory=dict)
     runtime_environment: dict[str, Any] = field(default_factory=dict)
+    # Per-detection `unavailable_in_container` flags for host-fs-dependent
+    # probes (PCI accel, kernel crypto, ktls, FIPS, TPM, kernel info, OS
+    # release, PKCS#11 modules).  Populated only when the report was
+    # produced inside a container without --host-mount; empty otherwise.
+    # The fleet aggregator counts hosts per key under
+    # host_fs_detections_unavailable_host_count.
+    host_fs_detections_unavailable: dict[str, dict[str, Any]] = field(
+        default_factory=dict
+    )
     packages: dict[str, Any] = field(default_factory=dict)
     replace_required: bool = False
     os_release: dict[str, Any] = field(default_factory=dict)
@@ -711,6 +750,24 @@ def detect_accelerators() -> list[dict[str, Any]]:
     return out
 
 
+def detect_pci_accelerators() -> dict[str, Any]:
+    """Dict-returning sibling of detect_accelerators().  Returns the same
+    list of detected accelerators under key `items`, plus an
+    `unavailable_in_container` annotation when the result depends on
+    `lspci` / /dev probing inside a container without --host-mount.
+    Use this when callers need to surface "we couldn't see the host's
+    PCI bus from in here" rather than silently emit an empty list."""
+    items = detect_accelerators()
+    out: dict[str, Any] = {"items": items}
+    note = host_fs_unavailable_note(
+        "PCI accelerator detection",
+        "lspci output and /dev hints (/dev/kfd, /dev/nvidia*, etc.)",
+    )
+    if note:
+        out.update(note)
+    return out
+
+
 def detect_pkcs11_modules(family: str = "unknown") -> list[str]:
     """Walk the family-appropriate PKCS#11 directories plus the always-
     on vendor paths.  Returns a sorted, de-duplicated list of *.so and
@@ -728,32 +785,44 @@ def detect_pkcs11_modules(family: str = "unknown") -> list[str]:
 
 
 def detect_tpm_pqc() -> dict[str, Any]:
+    note = host_fs_unavailable_note(
+        "TPM PQC detection", "/dev/tpmrm0, /dev/tpm0 and tpm2_getcap"
+    )
     if not shutil.which("tpm2_getcap"):
-        return {
+        out: dict[str, Any] = {
             "present": host_path("/dev/tpmrm0").exists()
             or host_path("/dev/tpm0").exists(),
             "tools": False,
             "note": "tpm2-tools not installed; TPM 2.0 chips today do not implement NIST PQC",
         }
-    rc, out = _run(["tpm2_getcap", "algorithms"], timeout=5)
+        if note:
+            out.update(note)
+        return out
+    rc, out_text = _run(["tpm2_getcap", "algorithms"], timeout=5)
     if rc != 0:
-        return {
+        out = {
             "present": True,
             "tools": True,
             "note": "tpm2_getcap failed",
-            "raw": out[:200],
+            "raw": out_text[:200],
         }
+        if note:
+            out.update(note)
+        return out
     has_pqc = bool(
         re.search(
-            r"ml[-_ ]?kem|ml[-_ ]?dsa|kyber|dilithium|sphincs", out, re.IGNORECASE
+            r"ml[-_ ]?kem|ml[-_ ]?dsa|kyber|dilithium|sphincs", out_text, re.IGNORECASE
         )
     )
-    return {
+    out = {
         "present": True,
         "tools": True,
         "pqc_advertised": has_pqc,
         "note": "TPM 2.0 specs do not yet mandate PQC; almost all shipped TPMs answer 'no'",
     }
+    if note:
+        out.update(note)
+    return out
 
 
 def detect_kernel_crypto_hw() -> list[str]:
@@ -842,6 +911,12 @@ def detect_fips_mode() -> dict[str, Any]:
         rc, out = _run(["openssl", "list", "-providers", "-verbose"], timeout=5)
         if rc == 0:
             info["openssl_provider"] = detect_fips_mode_from_providers_text(out)
+    note = host_fs_unavailable_note(
+        "FIPS mode detection",
+        "/proc/sys/crypto/fips_enabled and the in-container openssl binary",
+    )
+    if note:
+        info.update(note)
     return info
 
 
@@ -1298,7 +1373,22 @@ def detect_os() -> dict[str, Any]:
     version_codename  e.g. "jammy", "bookworm", or None
     pretty_name       full string from os-release / sysctl
     package_manager   first tool on PATH for this family, or None
-    """
+
+    When running inside a container without --host-mount, the result
+    additionally carries `unavailable_in_container: True` and a `reason`
+    string — /etc/os-release inside a container is the container image's
+    OS, not the host's, so consumers can warn rather than misreport."""
+    out = _detect_os_impl()
+    note = host_fs_unavailable_note(
+        "OS release detection",
+        "/etc/os-release, /usr/lib/os-release, /etc/redhat-release, /etc/debian_version",
+    )
+    if note:
+        out.update(note)
+    return out
+
+
+def _detect_os_impl() -> dict[str, Any]:
     if is_macos():
         ver = _sysctl("kern.osproductversion") or platform.mac_ver()[0]
         return {
@@ -1479,7 +1569,13 @@ def detect_kernel_info(os_release: dict[str, Any] | None = None) -> dict[str, An
     duplicate that and now consumes the precomputed dict for backward
     compatibility — `os_release_id` and `os_release_version_id` are kept
     on the kernel_info dict so existing aggregator/CSV consumers don't
-    break when they read either location."""
+    break when they read either location.
+
+    When running inside a container without --host-mount, the dict
+    additionally carries `unavailable_in_container: True` and a `reason`
+    string — /etc/redhat-release reflects the container image, and
+    /proc/crypto is shared with the host kernel but PQC awareness still
+    needs explicit acknowledgement that the container is in play."""
     info: dict[str, Any] = {
         "release": platform.release(),
         "system": platform.system(),
@@ -1505,6 +1601,12 @@ def detect_kernel_info(os_release: dict[str, Any] | None = None) -> dict[str, An
         )
     except OSError:
         info["proc_crypto_pqc"] = []
+    note = host_fs_unavailable_note(
+        "Kernel info detection",
+        "/etc/redhat-release and /proc/crypto",
+    )
+    if note:
+        info.update(note)
     return info
 
 
@@ -1931,6 +2033,51 @@ def parse_cgroup_for_container(text: str) -> str | None:
     return None
 
 
+# Catalogue of detection probes whose results depend on host filesystem
+# paths or host-only commands (lspci / dmidecode).  Used by
+# build_host_fs_detections_unavailable() to compute one annotation per
+# probe when running inside a container without --host-mount.  The keys
+# match Report field names so the aggregator can correlate counts back
+# to the field they describe.
+_HOST_FS_DEPENDENT_DETECTIONS: tuple[tuple[str, str, str], ...] = (
+    (
+        "accelerators",
+        "PCI accelerator detection",
+        "lspci output and /dev hints (/dev/kfd, /dev/nvidia*, etc.)",
+    ),
+    ("kernel_crypto_hw", "Kernel crypto hardware detection", "/proc/crypto"),
+    ("ktls", "kTLS module detection", "/proc/modules and /sys/module/tls"),
+    ("fips", "FIPS mode detection", "/proc/sys/crypto/fips_enabled"),
+    ("tpm_pqc", "TPM PQC detection", "/dev/tpmrm0, /dev/tpm0 and tpm2_getcap"),
+    ("kernel_info", "Kernel info detection", "/etc/redhat-release and /proc/crypto"),
+    (
+        "os_release",
+        "OS release detection",
+        "/etc/os-release, /usr/lib/os-release, /etc/redhat-release, /etc/debian_version",
+    ),
+    (
+        "pkcs11_modules",
+        "PKCS#11 module scan",
+        "/usr/lib*/<arch>/ and /usr/lib*/pkcs11/ under host /usr",
+    ),
+)
+
+
+def build_host_fs_detections_unavailable() -> dict[str, dict[str, Any]]:
+    """Compute the `host_fs_detections_unavailable` map for the current
+    invocation.  Returns an empty dict on bare metal or when --host-mount
+    is in effect; otherwise returns one annotation per host-fs-dependent
+    probe in `_HOST_FS_DEPENDENT_DETECTIONS`.  The aggregator preserves
+    these keys so fleet rollups can report "X hosts had detection Y
+    unavailable in container" without re-running detection."""
+    out: dict[str, dict[str, Any]] = {}
+    for key, label, host_resources in _HOST_FS_DEPENDENT_DETECTIONS:
+        note = host_fs_unavailable_note(label, host_resources)
+        if note:
+            out[key] = note
+    return out
+
+
 def detect_runtime_environment() -> dict[str, Any]:
     """Identify whether we're executing inside a container.  Used by
     every detection function that may need a `unavailable_in_container`
@@ -2172,7 +2319,9 @@ def aggregate_reports(reports: list[dict[str, Any]]) -> dict[str, Any]:
     Output:
       total_hosts, by_arch, by_os_release_id, by_isa_tier, by_verdict,
       by_runtime_environment, accelerator_kinds (count of hosts with
-      each kind), unique_cpu_models, replace_required_count.
+      each kind), unique_cpu_models, replace_required_count,
+      host_fs_detections_unavailable_host_count (count of hosts where
+      each host-fs-dependent probe was flagged unavailable in container).
     """
     from collections import Counter
 
@@ -2187,6 +2336,7 @@ def aggregate_reports(reports: list[dict[str, Any]]) -> dict[str, Any]:
     by_env: Counter[str] = Counter()
     cpu_models: set[str] = set()
     accel_kinds: Counter[str] = Counter()
+    detections_unavailable: Counter[str] = Counter()
     replace_required = 0
     for r in reports:
         by_arch[r.get("arch", "?")] += 1
@@ -2205,6 +2355,12 @@ def aggregate_reports(reports: list[dict[str, Any]]) -> dict[str, Any]:
             if k not in seen_kinds:
                 accel_kinds[k] += 1
                 seen_kinds.add(k)
+        # A detection key is counted at most once per host: the aggregator
+        # only cares whether *any* host had probe Y flagged unavailable,
+        # not how many duplicate annotations a single host carried.
+        for det_key, det_info in (r.get("host_fs_detections_unavailable") or {}).items():
+            if isinstance(det_info, dict) and det_info.get("unavailable_in_container"):
+                detections_unavailable[det_key] += 1
         if r.get("replace_required"):
             replace_required += 1
     out["by_arch"] = dict(by_arch)
@@ -2213,6 +2369,7 @@ def aggregate_reports(reports: list[dict[str, Any]]) -> dict[str, Any]:
     out["by_verdict"] = dict(by_verdict)
     out["by_runtime_environment"] = dict(by_env)
     out["accelerator_kinds_host_count"] = dict(accel_kinds)
+    out["host_fs_detections_unavailable_host_count"] = dict(detections_unavailable)
     out["unique_cpu_models"] = sorted(cpu_models)
     out["replace_required_count"] = replace_required
     return out
@@ -2237,6 +2394,7 @@ def aggregate_to_csv(rollup: dict[str, Any]) -> str:
         "by_verdict",
         "by_runtime_environment",
         "accelerator_kinds_host_count",
+        "host_fs_detections_unavailable_host_count",
     ):
         for k, v in (rollup.get(group) or {}).items():
             w.writerow([group, k, v])
@@ -5656,6 +5814,7 @@ def main() -> int:
     isa_t, isa_reason = isa_tier(arch, isa_score, flags)
     mem_t, mem_reason = memory_tier(total_gb)
     runtime_env = detect_runtime_environment()
+    host_fs_detections_unavailable = build_host_fs_detections_unavailable()
     accels = detect_accelerators()
     accels.extend(detect_network_hsms())
     os_release = detect_os()
@@ -5757,6 +5916,7 @@ def main() -> int:
         cnsa_2_0=cnsa_2_0,
         trust_store=trust_store_info,
         runtime_environment=runtime_env,
+        host_fs_detections_unavailable=host_fs_detections_unavailable,
         packages=packages_info,
         replace_required=replace_required,
         os_release=os_release,

--- a/tests/test_container_annotation.py
+++ b/tests/test_container_annotation.py
@@ -1,0 +1,292 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-feature `unavailable_in_container` annotation tests.
+
+Issue #1 §4 acceptance promised that every detection function whose
+result depends on /proc, /sys, /dev, /etc, lspci, or dmidecode would
+annotate its output with `unavailable_in_container: true` and a
+`reason` string when running inside a container without `--host-mount`.
+Issue #38 documents that prior to this fix the literal string only
+existed in a docstring.  These tests cover:
+
+  - the helper `host_fs_unavailable_note`
+  - inline annotation on a dict-returning probe (`detect_os`)
+  - the canonical dict-returning sibling `detect_pci_accelerators`
+  - `build_host_fs_detections_unavailable` map population
+  - aggregator preservation of the flag for fleet rollups
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import pqc_readiness as pr
+
+
+@pytest.fixture
+def container_no_host_mount(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Simulate "running inside a container without --host-mount" by
+    forcing detect_runtime_environment() to report container and clearing
+    HOST_PREFIX.  Detection helpers should then emit the
+    `unavailable_in_container` annotation."""
+    monkeypatch.setattr(pr, "HOST_PREFIX", "")
+    monkeypatch.setattr(
+        pr,
+        "detect_runtime_environment",
+        lambda: {"environment": "container", "evidence": "test stub"},
+    )
+
+
+@pytest.fixture
+def container_with_host_mount(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Simulate container + --host-mount.  Detection helpers should NOT
+    emit the annotation because /host bind-mounts make the host fs
+    visible to the container."""
+    monkeypatch.setattr(pr, "HOST_PREFIX", "/host")
+    monkeypatch.setattr(
+        pr,
+        "detect_runtime_environment",
+        lambda: {"environment": "container", "evidence": "test stub"},
+    )
+
+
+@pytest.fixture
+def bare_metal(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pr, "HOST_PREFIX", "")
+    monkeypatch.setattr(
+        pr,
+        "detect_runtime_environment",
+        lambda: {"environment": "host", "evidence": "test stub"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# host_fs_unavailable_note — the central helper
+# ---------------------------------------------------------------------------
+
+def test_host_fs_unavailable_note_returns_none_on_bare_metal(
+    bare_metal: None,
+) -> None:
+    assert pr.host_fs_unavailable_note("X probe", "/proc/X") is None
+
+
+def test_host_fs_unavailable_note_returns_none_with_host_mount(
+    container_with_host_mount: None,
+) -> None:
+    """--host-mount in effect: detection reads the bind-mounted host fs,
+    so its result is trustworthy.  No annotation."""
+    assert pr.host_fs_unavailable_note("X probe", "/proc/X") is None
+
+
+def test_host_fs_unavailable_note_emits_flag_in_container(
+    container_no_host_mount: None,
+) -> None:
+    note = pr.host_fs_unavailable_note(
+        "PCI accelerator detection", "lspci output"
+    )
+    assert note is not None
+    assert note["unavailable_in_container"] is True
+    assert "PCI accelerator detection" in note["reason"]
+    assert "lspci output" in note["reason"]
+    assert "--host-mount" in note["reason"]
+
+
+# ---------------------------------------------------------------------------
+# detect_pci_accelerators — canonical example called out in issue #38
+# ---------------------------------------------------------------------------
+
+def test_detect_pci_accelerators_emits_flag_in_container(
+    container_no_host_mount: None, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per issue #38: `detect_pci_accelerators` is the canonical probe
+    that depends on lspci output and /dev hints.  Inside a container
+    without --host-mount it MUST surface the flag instead of silently
+    returning an empty list (which is indistinguishable from "host has
+    no PCI accelerators")."""
+    monkeypatch.setattr(pr, "detect_accelerators", lambda: [])
+    out = pr.detect_pci_accelerators()
+    assert out["items"] == []
+    assert out["unavailable_in_container"] is True
+    assert "lspci" in out["reason"]
+
+
+def test_detect_pci_accelerators_no_flag_on_bare_metal(
+    bare_metal: None, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        pr, "detect_accelerators", lambda: [{"kind": "tpm", "name": "Test"}]
+    )
+    out = pr.detect_pci_accelerators()
+    assert out["items"] == [{"kind": "tpm", "name": "Test"}]
+    assert "unavailable_in_container" not in out
+    assert "reason" not in out
+
+
+def test_detect_pci_accelerators_no_flag_with_host_mount(
+    container_with_host_mount: None, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When --host-mount is in effect the lspci output reflects the host
+    (operator runs `chroot /host lspci`-equivalent paths via
+    HOST_PREFIX), so no flag."""
+    monkeypatch.setattr(pr, "detect_accelerators", lambda: [])
+    out = pr.detect_pci_accelerators()
+    assert "unavailable_in_container" not in out
+
+
+# ---------------------------------------------------------------------------
+# Inline annotation on dict-returning probes — detect_os
+# ---------------------------------------------------------------------------
+
+def test_detect_os_annotates_inline_in_container(
+    container_no_host_mount: None, tmp_path: Any, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inside a container without --host-mount, /etc/os-release is the
+    container image's OS, not the host's.  detect_os() must annotate so
+    consumers don't misreport the host distro."""
+    # Stub /etc/os-release so _detect_os_impl returns a known dict.
+    target = tmp_path / "etc" / "os-release"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        'ID=ubi9\nVERSION_ID="9.6"\nID_LIKE="rhel fedora"\n'
+        'PRETTY_NAME="Red Hat Universal Base Image 9.6"\n'
+    )
+    # _detect_os_impl reads via host_path() which only redirects when
+    # HOST_PREFIX is set; we keep HOST_PREFIX empty (matches the
+    # "container without --host-mount" scenario) and instead monkey-patch
+    # _detect_os_impl to a minimal known result so the test does not
+    # depend on the test runner's own /etc/os-release.
+    monkeypatch.setattr(
+        pr,
+        "_detect_os_impl",
+        lambda: {
+            "family": "rhel", "id": "ubi9", "version_id": "9.6",
+            "version_codename": None, "pretty_name": "Red Hat UBI 9.6",
+            "package_manager": None,
+        },
+    )
+    out = pr.detect_os()
+    assert out["family"] == "rhel"
+    assert out["unavailable_in_container"] is True
+    assert "/etc/os-release" in out["reason"]
+
+
+def test_detect_os_no_flag_on_bare_metal(
+    bare_metal: None, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        pr,
+        "_detect_os_impl",
+        lambda: {"family": "fedora", "id": "fedora", "version_id": "44"},
+    )
+    out = pr.detect_os()
+    assert "unavailable_in_container" not in out
+
+
+# ---------------------------------------------------------------------------
+# build_host_fs_detections_unavailable — Report-level map
+# ---------------------------------------------------------------------------
+
+def test_build_host_fs_detections_unavailable_empty_on_bare_metal(
+    bare_metal: None,
+) -> None:
+    assert pr.build_host_fs_detections_unavailable() == {}
+
+
+def test_build_host_fs_detections_unavailable_empty_with_host_mount(
+    container_with_host_mount: None,
+) -> None:
+    assert pr.build_host_fs_detections_unavailable() == {}
+
+
+def test_build_host_fs_detections_unavailable_populated_in_container(
+    container_no_host_mount: None,
+) -> None:
+    out = pr.build_host_fs_detections_unavailable()
+    # Every catalogued probe should be present.
+    expected = {
+        "accelerators", "kernel_crypto_hw", "ktls", "fips", "tpm_pqc",
+        "kernel_info", "os_release", "pkcs11_modules",
+    }
+    assert set(out) == expected
+    for key, note in out.items():
+        assert note["unavailable_in_container"] is True
+        assert note["reason"], f"empty reason for {key}"
+
+
+# ---------------------------------------------------------------------------
+# Aggregator preserves the flag — required by issue #38 acceptance
+# ---------------------------------------------------------------------------
+
+def test_aggregator_counts_host_fs_detections_unavailable() -> None:
+    """Issue #38 acceptance: 'fleet rollups can report X hosts had
+    detection Y unavailable in container'.  Two of three reports flag
+    `accelerators`; one flags `tpm_pqc`.  The rollup must surface those
+    counts under host_fs_detections_unavailable_host_count."""
+    reports = [
+        {
+            "schema_version": pr.SCHEMA_VERSION,
+            "arch": "x86_64", "isa_tier": "good", "verdict": "GOOD",
+            "cpu_model": "Test", "kernel_info": {"os_release_id": "rhel"},
+            "runtime_environment": {"environment": "container"},
+            "accelerators": [],
+            "host_fs_detections_unavailable": {
+                "accelerators": {
+                    "unavailable_in_container": True, "reason": "..."
+                },
+                "tpm_pqc": {
+                    "unavailable_in_container": True, "reason": "..."
+                },
+            },
+            "replace_required": False,
+        },
+        {
+            "schema_version": pr.SCHEMA_VERSION,
+            "arch": "x86_64", "isa_tier": "good", "verdict": "GOOD",
+            "cpu_model": "Test", "kernel_info": {"os_release_id": "rhel"},
+            "runtime_environment": {"environment": "container"},
+            "accelerators": [],
+            "host_fs_detections_unavailable": {
+                "accelerators": {
+                    "unavailable_in_container": True, "reason": "..."
+                },
+            },
+            "replace_required": False,
+        },
+        {
+            "schema_version": pr.SCHEMA_VERSION,
+            "arch": "x86_64", "isa_tier": "good", "verdict": "GOOD",
+            "cpu_model": "Test", "kernel_info": {"os_release_id": "rhel"},
+            "runtime_environment": {"environment": "host"},
+            "accelerators": [],
+            "host_fs_detections_unavailable": {},
+            "replace_required": False,
+        },
+    ]
+    out = pr.aggregate_reports(reports)
+    counts = out["host_fs_detections_unavailable_host_count"]
+    assert counts == {"accelerators": 2, "tpm_pqc": 1}
+
+
+def test_aggregator_handles_missing_field_gracefully() -> None:
+    """Reports written before this field existed must aggregate without
+    error; the count map is simply empty."""
+    reports = [
+        {
+            "schema_version": pr.SCHEMA_VERSION,
+            "arch": "x86_64", "isa_tier": "good", "verdict": "GOOD",
+            "cpu_model": "Test", "kernel_info": {"os_release_id": "rhel"},
+            "runtime_environment": {"environment": "host"},
+            "accelerators": [], "replace_required": False,
+        },
+    ]
+    out = pr.aggregate_reports(reports)
+    assert out["host_fs_detections_unavailable_host_count"] == {}
+
+
+def test_aggregator_csv_includes_unavailable_group() -> None:
+    rollup = {
+        "total_hosts": 1, "replace_required_count": 0,
+        "host_fs_detections_unavailable_host_count": {"accelerators": 1},
+    }
+    csv_text = pr.aggregate_to_csv(rollup)
+    assert "host_fs_detections_unavailable_host_count,accelerators,1" in csv_text


### PR DESCRIPTION
## Summary

Issue #1 §4 acceptance promised that detection probes whose result depends on the host filesystem (`/proc`, `/sys`, `/dev`, `/etc`, `lspci`, `dmidecode`) would annotate themselves with `unavailable_in_container: true` and a `reason` string when running inside a container without `--host-mount`. Issue #38 caught that only a docstring referenced the flag — the detection functions silently returned empty results indistinguishable from "host has no <feature>".

This change adds a single helper, `host_fs_unavailable_note()`, gated on `HOST_PREFIX == ""` AND `detect_runtime_environment().environment == "container"`, and applies it three ways:

- **Inline on dict-returning probes**: `detect_os`, `detect_kernel_info`, `detect_fips_mode`, `detect_tpm_pqc` get the flag merged into their result dicts.
- **Via `detect_pci_accelerators()`** — new dict-returning sibling of `detect_accelerators()` that wraps the list under `items` and surfaces the flag. This is the canonical example called out in #38.
- **Uniformly via `Report.host_fs_detections_unavailable`** — a new map populated in `main()` from `build_host_fs_detections_unavailable()`. Covers all eight host-fs-dependent probes (accelerators, kernel_crypto_hw, ktls, fips, tpm_pqc, kernel_info, os_release, pkcs11_modules).

The aggregator now counts hosts per detection key under `host_fs_detections_unavailable_host_count` and surfaces the group in the CSV view, so fleet rollups can directly answer *"X hosts had detection Y unavailable in container."*

## Test plan

- [x] 14 new tests in `tests/test_container_annotation.py` cover the helper, inline annotation on `detect_os`, the canonical `detect_pci_accelerators`, the Report-level map, aggregator preservation, and back-compat with reports predating the field.
- [x] `make check` (ruff + mypy --strict + pytest): 256 passed.
- [x] CodeRabbit `cr --plain --type uncommitted`: no findings.
- [x] No schema break — existing `Report` fields unchanged; new field defaults to empty dict.

Closes #38