### PR TITLE
fix(ssh): add classical bucket to ssh_pqc.kex_groups (closes #40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ keep the same version. Aggregation refuses to merge files whose
 | `tpm_pqc` | TPM presence and any PQC capability advertised. |
 | `memory_bandwidth_gb_s` | Memory bandwidth measurement (null if not measured). |
 | `memory_bandwidth_method` | How the bandwidth value was obtained, or `not-measured`. |
-| `ssh_pqc` | OpenSSH `ssh -Q kex` PQC / hybrid kex availability. |
+| `ssh_pqc` | OpenSSH `ssh -Q kex` availability. `kex_groups` splits the detected kex names into `pure_pqc` / `hybrid` / `classical` buckets, mirroring `openssl.tls_groups`. |
 | `ipsec_pqc` | strongSwan / Libreswan PQC and hybrid IKE state. |
 | `nss` | NSS PQC algorithm exposure. |
 | `kernel_info` | Kernel version, build flags relevant to crypto, and module list. |

--- a/pqc_readiness.py
+++ b/pqc_readiness.py
@@ -1017,30 +1017,53 @@ _CLASSICAL_SSH_TOKEN_RE = re.compile(
     r"(?:nistp\d+|x25519|x448|secp\d+r1)",
     re.IGNORECASE,
 )
+# Full classical SSH kex names recognised by OpenSSH's `-Q kex` set.
+# Used to populate the `classical` bucket for parity with
+# classify_tls_groups (issue #9, audit #40).  Names that match no
+# pattern are dropped rather than silently lumped into classical, the
+# same way classify_tls_groups handles unknown TLS group names.
+_CLASSICAL_SSH_KEX_RE = re.compile(
+    r"^(?:"
+    r"diffie-hellman-group(?:\d+|-exchange)-sha\d+"
+    r"|ecdh-sha2-nistp\d+"
+    r"|curve(?:25519|448)-sha\d+(?:@\S+)?"
+    r")$",
+    re.IGNORECASE,
+)
 
 
-def classify_ssh_kex(pqc_kex: list[str]) -> dict[str, list[str]]:
-    """Split detected PQC-relevant SSH kex algorithms into pure-PQC and
-    hybrid buckets.  A name that contains both a PQC and a classical
-    token is hybrid; PQC-token-only names are pure PQC.  As of 2026 every
-    shipped OpenSSH PQC kex is hybrid, but the pure_pqc bucket exists so
-    future RFC-adopted pure-PQC kex are surfaced the day they arrive."""
+def classify_ssh_kex(kexes: list[str]) -> dict[str, list[str]]:
+    """Split SSH kex algorithm names into pure_pqc / hybrid / classical
+    buckets, mirroring classify_tls_groups.  A name with a PQC token and
+    a classical token is hybrid; PQC-token-only names are pure_pqc;
+    recognised classical kex names (DH groups, ECDH NIST, curve25519/448)
+    land in classical.  As of 2026 every shipped OpenSSH PQC kex is
+    hybrid, but the pure_pqc bucket exists so future RFC-adopted pure-PQC
+    kex surface the day they arrive.  Unrecognised names are dropped so
+    the report stays honest about what we don't catalogue yet."""
     pure: set[str] = set()
     hybrid: set[str] = set()
-    for k in pqc_kex:
-        if not _PQC_SSH_TOKEN_RE.search(k):
-            continue
-        if _CLASSICAL_SSH_TOKEN_RE.search(k):
-            hybrid.add(k)
-        else:
-            pure.add(k)
-    return {"pure_pqc": sorted(pure), "hybrid": sorted(hybrid)}
+    classical: set[str] = set()
+    for k in kexes:
+        if _PQC_SSH_TOKEN_RE.search(k):
+            if _CLASSICAL_SSH_TOKEN_RE.search(k):
+                hybrid.add(k)
+            else:
+                pure.add(k)
+        elif _CLASSICAL_SSH_KEX_RE.match(k):
+            classical.add(k)
+    return {
+        "pure_pqc": sorted(pure),
+        "hybrid": sorted(hybrid),
+        "classical": sorted(classical),
+    }
 
 
 def parse_ssh_kex(text: str) -> dict[str, Any]:
     """Parse `ssh -Q kex` output.  Returns a dict with the full kex
     count, the flat PQC subset (ML-KEM hybrids and the older sntrup761
-    NTRU Prime hybrid), and a `kex_groups` split into pure_pqc / hybrid.
+    NTRU Prime hybrid), and a `kex_groups` split into pure_pqc / hybrid /
+    classical.
 
     The flat `pqc_kex` list is preserved for back-compat with consumers
     that already key off it; new consumers should prefer `kex_groups`."""
@@ -1050,7 +1073,7 @@ def parse_ssh_kex(text: str) -> dict[str, Any]:
         "available": True,
         "kex_count": len(kexes),
         "pqc_kex": pqc,
-        "kex_groups": classify_ssh_kex(pqc),
+        "kex_groups": classify_ssh_kex(kexes),
     }
 
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1359,6 +1359,54 @@ def test_parse_ssh_kex_emits_kex_groups_and_back_compat_pqc_kex() -> None:
         "mlkem768x25519-sha256", "sntrup761x25519-sha512",
     ]
     assert out["kex_groups"]["pure_pqc"] == []
+    # Issue #40: classical SSH kex must surface in its own bucket so
+    # downstream tooling can inventory classical-only SSH posture from a
+    # single field, the way it already can for tls_groups.
+    assert out["kex_groups"]["classical"] == [
+        "curve25519-sha256",
+        "diffie-hellman-group14-sha256",
+        "ecdh-sha2-nistp256",
+    ]
+
+
+def test_classify_ssh_kex_buckets_rhel10_fixture_into_three_groups() -> None:
+    """Regression for issue #40: every kex name from the rhel10 ssh -Q
+    kex fixture must land in exactly one of pure_pqc / hybrid / classical
+    (the same three-bucket contract issue #9 introduced for TLS).  The
+    classical bucket must be non-empty — historical behaviour silently
+    dropped curve25519-sha256, ecdh-sha2-nistp*, and the diffie-hellman
+    group kex set, which left consumers unable to inventory classical
+    SSH posture from kex_groups alone."""
+    text = (FIXTURES / "ssh-kex-rhel10.txt").read_text()
+    out = pr.parse_ssh_kex(text)
+    kg = out["kex_groups"]
+    assert set(kg) == {"pure_pqc", "hybrid", "classical"}
+    classified = set(kg["pure_pqc"]) | set(kg["hybrid"]) | set(kg["classical"])
+    fixture_kexes = {ln.strip() for ln in text.splitlines() if ln.strip()}
+    # Every fixture entry must be classified; no kex is dropped.
+    assert classified == fixture_kexes
+    # No kex appears in more than one bucket.
+    assert len(classified) == (
+        len(kg["pure_pqc"]) + len(kg["hybrid"]) + len(kg["classical"])
+    )
+    # Sanity: classical bucket carries the expected baseline kex set.
+    assert "curve25519-sha256" in kg["classical"]
+    assert "ecdh-sha2-nistp256" in kg["classical"]
+    assert "diffie-hellman-group14-sha256" in kg["classical"]
+    # And the PQC pair still bucket as hybrid (no regression).
+    assert "mlkem768x25519-sha256" in kg["hybrid"]
+    assert "sntrup761x25519-sha512" in kg["hybrid"]
+
+
+def test_classify_ssh_kex_drops_unrecognised_names() -> None:
+    """Names that match no PQC and no classical pattern are dropped, the
+    same way classify_tls_groups treats unknown TLS groups.  This keeps
+    the report honest about what we don't yet catalogue."""
+    out = pr.classify_ssh_kex([
+        "unknown-future-kex-sha512",
+        "gss-group14-sha256-",  # GSS-API kex; out of scope for PQC inventory
+    ])
+    assert out == {"pure_pqc": [], "hybrid": [], "classical": []}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Issue #9 introduced a three-bucket `pure_pqc / hybrid / classical` split for TLS groups; the SSH path stopped at two and silently dropped classical kex (curve25519-sha256, ecdh-sha2-nistp\*, the DH-group set), leaving consumers unable to inventory classical-only SSH posture from `kex_groups` alone.
- `classify_ssh_kex()` now consumes the full `ssh -Q kex` list and returns `{pure_pqc, hybrid, classical}` for parity with `classify_tls_groups()`. A new `_CLASSICAL_SSH_KEX_RE` catalog covers the DH groups, ECDH NIST curves, and curve25519/448 family. Unrecognised names are dropped (same honesty rule TLS uses), not silently lumped into classical.
- README's `ssh_pqc` field documentation reflects the three-bucket shape.

## Test plan

- [x] `make check` (ruff + mypy --strict + pytest) — 250 passed (added 2 new regression tests)
- [x] `make check-readme` — every --help flag (24) appears in README.md
- [x] `cr --plain --type uncommitted` — no findings (run before commit; the post-commit hook hit CodeRabbit's hourly cap, so logging the pre-commit pass for the audit trail)
- [x] Three-bucket regression: every kex name from `tests/fixtures/ssh-kex-rhel10.txt` lands in exactly one of `pure_pqc / hybrid / classical`, with the expected classical baseline (curve25519, ecdh-nistp256, dh-group14) populated
- [x] Honesty test: unknown / out-of-catalog names (e.g. GSS-API kex) are dropped, not silently classified

Closes #40