### PR TITLE
fix(render): default 'reason' to 'unknown' in render_text unavailable branches (closes #56)

### DIFF
--- a/pqc_readiness.py
+++ b/pqc_readiness.py
@@ -5438,7 +5438,7 @@ def render_text(r: Report) -> str:
     if r.benchmark:
         L.append(C.wrap(C.BOLD, "6. Microbenchmark"))
         if not r.benchmark.get("available"):
-            L.append(f"   unavailable: {r.benchmark.get('reason')}")
+            L.append(f"   unavailable: {r.benchmark.get('reason', 'unknown')}")
         else:
             L.append(
                 f"   engine: {r.benchmark['engine']}, {r.benchmark['seconds_per_test']}s per test, "
@@ -5466,7 +5466,7 @@ def render_text(r: Report) -> str:
         L.append(C.wrap(C.BOLD, "6b. TLS handshake benchmark (loopback)"))
         b = r.benchmark_tls_handshake
         if not b.get("available"):
-            L.append(f"   unavailable: {b.get('reason')}")
+            L.append(f"   unavailable: {b.get('reason', 'unknown')}")
         else:
             L.append(
                 f"   engine: {b.get('engine')}, transport: {b.get('transport')}, "

--- a/tests/test_render_text.py
+++ b/tests/test_render_text.py
@@ -200,12 +200,20 @@ def test_render_text_empty_report_is_non_empty_and_safe() -> None:
             id="benchmark-unavailable-with-reason",
         ),
         pytest.param(
+            lambda r: setattr(r, "benchmark", {"available": False}),
+            id="benchmark-unavailable-without-reason",
+        ),
+        pytest.param(
             lambda r: setattr(r, "benchmark_tls_handshake", {}),
             id="bench-tls-empty",
         ),
         pytest.param(
             lambda r: setattr(r, "benchmark_tls_handshake", {"available": False, "reason": "loopback failed"}),
             id="bench-tls-unavailable-with-reason",
+        ),
+        pytest.param(
+            lambda r: setattr(r, "benchmark_tls_handshake", {"available": False}),
+            id="bench-tls-unavailable-without-reason",
         ),
         pytest.param(lambda r: setattr(r, "per_algo", {}), id="per-algo-empty"),
         pytest.param(


### PR DESCRIPTION
## Summary

- `pqc_readiness.py:5441` (microbenchmark) and `:5469` (TLS-handshake bench) f-string `r.benchmark.get('reason')` / `b.get('reason')` with no fallback, so `available=False` dicts that omit the `reason` key render as `unavailable: None`. Both sites now use `.get('reason', 'unknown')` — the same fallback the OpenSSL section at `:5404` already uses, which keeps the three unavailable branches consistent.
- Reproduction (per the issue):

  ```python
  >>> import pqc_readiness as pr
  >>> r = pr.Report(); r.benchmark = {'available': False}
  >>> 'None' in pr.render_text(r)
  True   # before
  False  # after
  ```

- `render_markdown` audited alongside the fix per the issue's request: it only renders the benchmark / TLS-handshake sections when `available=True`, so no equivalent leak exists today.

## Test plan

- [x] Two new parametrize cases added to `tests/test_render_text.py::test_render_text_partial_population_does_not_raise_or_leak_none` (`benchmark-unavailable-without-reason`, `bench-tls-unavailable-without-reason`) — these exercise the missing-`reason` shape; the matrix's `'None' not in out` invariant catches the regression.
- [x] Manual repro (above) confirms the leak before the change and its absence after.
- [x] `make check`: ruff clean, mypy --strict clean, **304 pytest pass** (+2 new cases vs. main).
- [x] CodeRabbit (`cr --plain --type uncommitted`): org hit hourly cap with no review output produced; non-blocking per `CLAUDE.md` (same condition seen on #57).

Closes #56