### PR TITLE
refactor: split render_text into per-section helpers (audit B1)

### DIFF
--- a/pqc_readiness.py
+++ b/pqc_readiness.py
@@ -5527,20 +5527,27 @@ def _render_text_header(r: Report) -> list[str]:
     return L
 
 
-def render_text(r: Report) -> str:
-    L: list[str] = []
-    sub = "-" * 76
-    L.extend(_render_text_header(r))
-
-    L.append(C.wrap(C.BOLD, "1. CPU instruction-set support for PQC"))
-    L.append(f"   Tier: {_tier_label(r.isa_tier)}  (score {r.isa_score})")
-    L.append(f"   {r.isa_reason}")
+def _render_text_isa(r: Report) -> list[str]:
+    """Section 1: CPU instruction-set support for PQC."""
+    L: list[str] = [
+        C.wrap(C.BOLD, "1. CPU instruction-set support for PQC"),
+        f"   Tier: {_tier_label(r.isa_tier)}  (score {r.isa_score})",
+        f"   {r.isa_reason}",
+    ]
     if r.isa_features:
         for _, info in sorted(r.isa_features.items()):
             L.append(f"     + {info['name']:<22} {info['purpose']}")
     else:
         L.append("     (no PQC-relevant ISA features detected)")
     L.append("")
+    return L
+
+
+def render_text(r: Report) -> str:
+    L: list[str] = []
+    sub = "-" * 76
+    L.extend(_render_text_header(r))
+    L.extend(_render_text_isa(r))
 
     L.append(C.wrap(C.BOLD, "2. Cryptographic accelerators / HSMs / TPMs"))
     if r.accelerators:

--- a/pqc_readiness.py
+++ b/pqc_readiness.py
@@ -5658,15 +5658,9 @@ def _render_text_os_crypto(r: Report) -> list[str]:
     return L
 
 
-def render_text(r: Report) -> str:
-    L: list[str] = []
-    sub = "-" * 76
-    L.extend(_render_text_header(r))
-    L.extend(_render_text_isa(r))
-    L.extend(_render_text_accelerators(r))
-    L.extend(_render_text_os_crypto(r))
-
-    L.append(C.wrap(C.BOLD, "4. PQC library capability (OpenSSL)"))
+def _render_text_openssl(r: Report) -> list[str]:
+    """Section 4: OpenSSL PQC capability (version, KEMs, sigs, TLS groups)."""
+    L: list[str] = [C.wrap(C.BOLD, "4. PQC library capability (OpenSSL)")]
     if not r.openssl.get("available"):
         L.append(f"   {r.openssl.get('reason', 'unknown')}")
     else:
@@ -5694,6 +5688,17 @@ def render_text(r: Report) -> str:
         if classical:
             L.append(f"   TLS classical groups:    {len(classical)} detected")
     L.append("")
+    return L
+
+
+def render_text(r: Report) -> str:
+    L: list[str] = []
+    sub = "-" * 76
+    L.extend(_render_text_header(r))
+    L.extend(_render_text_isa(r))
+    L.extend(_render_text_accelerators(r))
+    L.extend(_render_text_os_crypto(r))
+    L.extend(_render_text_openssl(r))
 
     L.append(C.wrap(C.BOLD, "5. NIST PQC parameter sizes (bytes)"))
     for name, sz in r.pqc_sizes.items():

--- a/pqc_readiness.py
+++ b/pqc_readiness.py
@@ -5772,6 +5772,24 @@ def _render_text_tls_handshake(r: Report) -> list[str]:
     return L
 
 
+def _render_text_per_algo(r: Report) -> list[str]:
+    """Section 7: Per-algorithm production verdict, conditional on r.per_algo."""
+    if not r.per_algo:
+        return []
+    L: list[str] = [C.wrap(C.BOLD, "7. Per-algorithm production verdict")]
+    for key, v in r.per_algo.items():
+        tier_s = _tier_label(v["tier"])
+        extra = ""
+        if "rate_per_core" in v:
+            extra = f" - {v['rate_per_core']:.1f} {v['metric']}/core, ~{v['rate_host_estimate']:.0f} host"
+        L.append(f"   {key:<22} {tier_s:<14}{extra}")
+        L.append(f"     {v.get('reason', '')}")
+        for note in v.get("notes", []):
+            L.append(C.wrap(C.YELLOW, f"     note: {note}"))
+    L.append("")
+    return L
+
+
 def render_text(r: Report) -> str:
     L: list[str] = []
     sub = "-" * 76
@@ -5783,19 +5801,7 @@ def render_text(r: Report) -> str:
     L.extend(_render_text_pqc_sizes(r))
     L.extend(_render_text_benchmark(r))
     L.extend(_render_text_tls_handshake(r))
-
-    if r.per_algo:
-        L.append(C.wrap(C.BOLD, "7. Per-algorithm production verdict"))
-        for key, v in r.per_algo.items():
-            tier_s = _tier_label(v["tier"])
-            extra = ""
-            if "rate_per_core" in v:
-                extra = f" - {v['rate_per_core']:.1f} {v['metric']}/core, ~{v['rate_host_estimate']:.0f} host"
-            L.append(f"   {key:<22} {tier_s:<14}{extra}")
-            L.append(f"     {v.get('reason', '')}")
-            for note in v.get("notes", []):
-                L.append(C.wrap(C.YELLOW, f"     note: {note}"))
-        L.append("")
+    L.extend(_render_text_per_algo(r))
 
     if r.production_estimate:
         L.append(C.wrap(C.BOLD, "8. Production capacity estimate (60% CPU headroom)"))

--- a/pqc_readiness.py
+++ b/pqc_readiness.py
@@ -5825,6 +5825,30 @@ def _render_text_production_estimate(r: Report) -> list[str]:
     return L
 
 
+def _render_text_trust_store(r: Report) -> list[str]:
+    """Section 9: trust store inventory, conditional on the trust-store
+    scanner having run successfully (r.trust_store['available'])."""
+    if not r.trust_store.get("available"):
+        return []
+    L: list[str] = [C.wrap(C.BOLD, "9. Trust store inventory")]
+    L.append(
+        f"   Scanned dirs:     {', '.join(r.trust_store.get('scanned_dirs', []))}"
+    )
+    L.append(f"   Total certs:      {r.trust_store.get('total_certs', 0)}")
+    L.append(f"   PQC certs:        {r.trust_store.get('pqc_certs', 0)}")
+    L.append(f"   Hybrid certs:     {r.trust_store.get('hybrid_certs', 0)}")
+    cats = r.trust_store.get("cert_categories") or {}
+    if cats:
+        L.append(
+            "   Categories:       "
+            f"classical={cats.get('classical', 0)}, "
+            f"hybrid_composite={cats.get('hybrid_composite', 0)}, "
+            f"pure_pqc={cats.get('pure_pqc', 0)}"
+        )
+    L.append("")
+    return L
+
+
 def render_text(r: Report) -> str:
     L: list[str] = []
     sub = "-" * 76
@@ -5838,24 +5862,7 @@ def render_text(r: Report) -> str:
     L.extend(_render_text_tls_handshake(r))
     L.extend(_render_text_per_algo(r))
     L.extend(_render_text_production_estimate(r))
-
-    if r.trust_store.get("available"):
-        L.append(C.wrap(C.BOLD, "9. Trust store inventory"))
-        L.append(
-            f"   Scanned dirs:     {', '.join(r.trust_store.get('scanned_dirs', []))}"
-        )
-        L.append(f"   Total certs:      {r.trust_store.get('total_certs', 0)}")
-        L.append(f"   PQC certs:        {r.trust_store.get('pqc_certs', 0)}")
-        L.append(f"   Hybrid certs:     {r.trust_store.get('hybrid_certs', 0)}")
-        cats = r.trust_store.get("cert_categories") or {}
-        if cats:
-            L.append(
-                "   Categories:       "
-                f"classical={cats.get('classical', 0)}, "
-                f"hybrid_composite={cats.get('hybrid_composite', 0)}, "
-                f"pure_pqc={cats.get('pure_pqc', 0)}"
-            )
-        L.append("")
+    L.extend(_render_text_trust_store(r))
 
     if r.cnsa_2_0:
         L.append(

--- a/pqc_readiness.py
+++ b/pqc_readiness.py
@@ -5577,14 +5577,9 @@ def _render_text_accelerators(r: Report) -> list[str]:
     return L
 
 
-def render_text(r: Report) -> str:
+def _render_text_kernel_crypto(r: Report) -> list[str]:
+    """Section 3a: kernel release, /proc/crypto PQC drivers and hw-accel, kTLS."""
     L: list[str] = []
-    sub = "-" * 76
-    L.extend(_render_text_header(r))
-    L.extend(_render_text_isa(r))
-    L.extend(_render_text_accelerators(r))
-
-    L.append(C.wrap(C.BOLD, "3. Operating-system crypto plumbing"))
     if r.kernel_info:
         rh = r.kernel_info.get("redhat_release") or {}
         if rh.get("raw"):
@@ -5605,6 +5600,12 @@ def render_text(r: Report) -> str:
             L.append(f"     ... and {len(r.kernel_crypto_hw) - 6} more")
     if r.ktls_supported is not None:
         L.append(f"   Kernel TLS:    {'yes' if r.ktls_supported else 'no'}")
+    return L
+
+
+def _render_text_fips(r: Report) -> list[str]:
+    """Section 3b: FIPS mode and FIPS/PQC conflict warning."""
+    L: list[str] = []
     if r.fips:
         L.append(
             f"   FIPS mode:     kernel={r.fips.get('kernel')}, openssl-provider={r.fips.get('openssl_provider')}"
@@ -5616,6 +5617,12 @@ def render_text(r: Report) -> str:
                 f"   ⚠  FIPS/PQC conflict: {r.fips_pqc_conflict.get('explanation')}",
             )
         )
+    return L
+
+
+def _render_text_ssh_ipsec_nss(r: Report) -> list[str]:
+    """Section 3c: OpenSSH PQC kex groups, strongSwan IPsec, NSS."""
+    L: list[str] = []
     if r.ssh_pqc.get("available"):
         pqc = r.ssh_pqc.get("pqc_kex") or []
         L.append(
@@ -5637,7 +5644,27 @@ def render_text(r: Report) -> str:
         L.append(
             f"   NSS:           {r.nss.get('version')}  (PQC-capable: {r.nss.get('pqc_capable')})"
         )
+    return L
+
+
+def _render_text_os_crypto(r: Report) -> list[str]:
+    """Section 3: OS crypto plumbing. Composite of kernel/proc-crypto, FIPS,
+    and SSH/IPsec/NSS sub-blocks under a single bold heading."""
+    L: list[str] = [C.wrap(C.BOLD, "3. Operating-system crypto plumbing")]
+    L.extend(_render_text_kernel_crypto(r))
+    L.extend(_render_text_fips(r))
+    L.extend(_render_text_ssh_ipsec_nss(r))
     L.append("")
+    return L
+
+
+def render_text(r: Report) -> str:
+    L: list[str] = []
+    sub = "-" * 76
+    L.extend(_render_text_header(r))
+    L.extend(_render_text_isa(r))
+    L.extend(_render_text_accelerators(r))
+    L.extend(_render_text_os_crypto(r))
 
     L.append(C.wrap(C.BOLD, "4. PQC library capability (OpenSSL)"))
     if not r.openssl.get("available"):

--- a/pqc_readiness.py
+++ b/pqc_readiness.py
@@ -5888,9 +5888,26 @@ def _render_text_trust_store(r: Report) -> list[str]:
     return L
 
 
-def render_text(r: Report) -> str:
-    L: list[str] = []
+def _render_text_verdict(r: Report) -> list[str]:
+    """Trailing verdict block: bracketed by horizontal rules with the
+    overall verdict, reason, and optional caveat."""
     sub = "-" * 76
+    L: list[str] = [
+        sub,
+        f"  VERDICT: {C.wrap(C.BOLD, r.verdict)}",
+        f"           {r.verdict_reason}",
+    ]
+    if r.verdict_caveat:
+        L.append(C.wrap(C.YELLOW, f"  CAVEAT:  {r.verdict_caveat}"))
+    L.append(sub)
+    return L
+
+
+def render_text(r: Report) -> str:
+    """Render the full report as plain text (color-aware via the module-
+    level C). Composes per-section helpers in numbered order; each helper
+    returns the lines it owns, including the trailing blank-line spacer."""
+    L: list[str] = []
     L.extend(_render_text_header(r))
     L.extend(_render_text_isa(r))
     L.extend(_render_text_accelerators(r))
@@ -5903,13 +5920,7 @@ def render_text(r: Report) -> str:
     L.extend(_render_text_production_estimate(r))
     L.extend(_render_text_trust_store(r))
     L.extend(_render_text_cnsa_2_0(r))
-
-    L.append(sub)
-    L.append(f"  VERDICT: {C.wrap(C.BOLD, r.verdict)}")
-    L.append(f"           {r.verdict_reason}")
-    if r.verdict_caveat:
-        L.append(C.wrap(C.YELLOW, f"  CAVEAT:  {r.verdict_caveat}"))
-    L.append(sub)
+    L.extend(_render_text_verdict(r))
     return "\n".join(L)
 
 

--- a/pqc_readiness.py
+++ b/pqc_readiness.py
@@ -5790,6 +5790,41 @@ def _render_text_per_algo(r: Report) -> list[str]:
     return L
 
 
+def _render_text_production_estimate(r: Report) -> list[str]:
+    """Section 8: production capacity estimate (60% CPU headroom),
+    conditional on r.production_estimate."""
+    if not r.production_estimate:
+        return []
+    L: list[str] = [
+        C.wrap(C.BOLD, "8. Production capacity estimate (60% CPU headroom)")
+    ]
+    e = r.production_estimate
+    if "tls_pqc_handshakes_per_sec" in e:
+        L.append(
+            f"   TLS-PQC handshakes/sec:           ~{e['tls_pqc_handshakes_per_sec']:,}"
+        )
+    if "ml_dsa_signatures_per_sec" in e:
+        L.append(
+            f"   ML-DSA-65 signatures/sec:         ~{e['ml_dsa_signatures_per_sec']:,}"
+        )
+    if "slh_dsa_sha2_128s_signatures_per_sec" in e:
+        L.append(
+            f"   SLH-DSA-SHA2-128s signatures/sec: ~{e['slh_dsa_sha2_128s_signatures_per_sec']}"
+        )
+    if "concurrent_connections_realistic" in e:
+        L.append(
+            f"   Concurrent conns (realistic):     ~{e['concurrent_connections_realistic']:,}  (192 KB/conn)"
+        )
+    if "concurrent_connections_theoretical_max" in e:
+        L.append(
+            f"   Concurrent conns (theoretical):   ~{e['concurrent_connections_theoretical_max']:,}  (32 KB/conn)"
+        )
+    if "assumptions" in e:
+        L.append(f"   ({e['assumptions']})")
+    L.append("")
+    return L
+
+
 def render_text(r: Report) -> str:
     L: list[str] = []
     sub = "-" * 76
@@ -5802,33 +5837,7 @@ def render_text(r: Report) -> str:
     L.extend(_render_text_benchmark(r))
     L.extend(_render_text_tls_handshake(r))
     L.extend(_render_text_per_algo(r))
-
-    if r.production_estimate:
-        L.append(C.wrap(C.BOLD, "8. Production capacity estimate (60% CPU headroom)"))
-        e = r.production_estimate
-        if "tls_pqc_handshakes_per_sec" in e:
-            L.append(
-                f"   TLS-PQC handshakes/sec:           ~{e['tls_pqc_handshakes_per_sec']:,}"
-            )
-        if "ml_dsa_signatures_per_sec" in e:
-            L.append(
-                f"   ML-DSA-65 signatures/sec:         ~{e['ml_dsa_signatures_per_sec']:,}"
-            )
-        if "slh_dsa_sha2_128s_signatures_per_sec" in e:
-            L.append(
-                f"   SLH-DSA-SHA2-128s signatures/sec: ~{e['slh_dsa_sha2_128s_signatures_per_sec']}"
-            )
-        if "concurrent_connections_realistic" in e:
-            L.append(
-                f"   Concurrent conns (realistic):     ~{e['concurrent_connections_realistic']:,}  (192 KB/conn)"
-            )
-        if "concurrent_connections_theoretical_max" in e:
-            L.append(
-                f"   Concurrent conns (theoretical):   ~{e['concurrent_connections_theoretical_max']:,}  (32 KB/conn)"
-            )
-        if "assumptions" in e:
-            L.append(f"   ({e['assumptions']})")
-        L.append("")
+    L.extend(_render_text_production_estimate(r))
 
     if r.trust_store.get("available"):
         L.append(C.wrap(C.BOLD, "9. Trust store inventory"))

--- a/pqc_readiness.py
+++ b/pqc_readiness.py
@@ -5691,6 +5691,17 @@ def _render_text_openssl(r: Report) -> list[str]:
     return L
 
 
+def _render_text_pqc_sizes(r: Report) -> list[str]:
+    """Section 5: NIST PQC parameter sizes (bytes) per algorithm."""
+    L: list[str] = [C.wrap(C.BOLD, "5. NIST PQC parameter sizes (bytes)")]
+    for name, sz in r.pqc_sizes.items():
+        role = sz.get("role", "")
+        nums = " ".join(f"{k}={v}" for k, v in sz.items() if k != "role")
+        L.append(f"   {name:<20} {role:<18} {nums}")
+    L.append("")
+    return L
+
+
 def render_text(r: Report) -> str:
     L: list[str] = []
     sub = "-" * 76
@@ -5699,13 +5710,7 @@ def render_text(r: Report) -> str:
     L.extend(_render_text_accelerators(r))
     L.extend(_render_text_os_crypto(r))
     L.extend(_render_text_openssl(r))
-
-    L.append(C.wrap(C.BOLD, "5. NIST PQC parameter sizes (bytes)"))
-    for name, sz in r.pqc_sizes.items():
-        role = sz.get("role", "")
-        nums = " ".join(f"{k}={v}" for k, v in sz.items() if k != "role")
-        L.append(f"   {name:<20} {role:<18} {nums}")
-    L.append("")
+    L.extend(_render_text_pqc_sizes(r))
 
     if r.benchmark:
         L.append(C.wrap(C.BOLD, "6. Microbenchmark"))

--- a/pqc_readiness.py
+++ b/pqc_readiness.py
@@ -5498,15 +5498,16 @@ def render_spdx(r: Report) -> str:
     return json.dumps(out, indent=2)
 
 
-def render_text(r: Report) -> str:
-    L: list[str] = []
+def _render_text_header(r: Report) -> list[str]:
+    """Banner and host-identity preamble (host, CPU, cores, memory, timestamp)."""
     bar = "=" * 76
-    sub = "-" * 76
-    L.append(C.wrap(C.BOLD, bar))
-    L.append(C.wrap(C.BOLD, "  Post-Quantum Cryptography Readiness Report"))
-    L.append(C.wrap(C.BOLD, bar))
-    L.append(f"  Host:          {r.hostname}  ({r.os}, {r.arch})")
-    L.append(f"  CPU:           {r.cpu_model}")
+    L: list[str] = [
+        C.wrap(C.BOLD, bar),
+        C.wrap(C.BOLD, "  Post-Quantum Cryptography Readiness Report"),
+        C.wrap(C.BOLD, bar),
+        f"  Host:          {r.hostname}  ({r.os}, {r.arch})",
+        f"  CPU:           {r.cpu_model}",
+    ]
     if r.cpu_freq_mhz:
         L.append(f"  Max freq:      {r.cpu_freq_mhz / 1000:.2f} GHz")
     L.append(
@@ -5523,6 +5524,13 @@ def render_text(r: Report) -> str:
         L.append(f"  Mem bandwidth: {r.memory_bandwidth_method}")
     L.append(f"  Generated:     {r.generated_at}")
     L.append("")
+    return L
+
+
+def render_text(r: Report) -> str:
+    L: list[str] = []
+    sub = "-" * 76
+    L.extend(_render_text_header(r))
 
     L.append(C.wrap(C.BOLD, "1. CPU instruction-set support for PQC"))
     L.append(f"   Tier: {_tier_label(r.isa_tier)}  (score {r.isa_score})")

--- a/pqc_readiness.py
+++ b/pqc_readiness.py
@@ -5734,6 +5734,44 @@ def _render_text_benchmark(r: Report) -> list[str]:
     return L
 
 
+def _render_text_tls_handshake(r: Report) -> list[str]:
+    """Section 6b: TLS-handshake benchmark (loopback). Conditional on
+    r.benchmark_tls_handshake."""
+    if not r.benchmark_tls_handshake:
+        return []
+    b = r.benchmark_tls_handshake
+    L: list[str] = [C.wrap(C.BOLD, "6b. TLS handshake benchmark (loopback)")]
+    if not b.get("available"):
+        L.append(f"   unavailable: {b.get('reason', 'unknown')}")
+    else:
+        L.append(
+            f"   engine: {b.get('engine')}, transport: {b.get('transport')}, "
+            f"{b.get('iterations_per_suite')} handshakes/suite"
+        )
+        for s in b.get("suites") or []:
+            if "error" in s:
+                L.append(
+                    f"   {s.get('label', s.get('role', '?')):<32} error: {s['error']}"
+                )
+                continue
+            if s.get("skipped"):
+                L.append(
+                    f"   {s.get('label', '?'):<32} skipped: {s.get('reason', '')}"
+                )
+                continue
+            hps = s.get("handshakes_per_sec")
+            ttfb = s.get("ttfb_ms_median")
+            bw = s.get("bytes_on_wire_per_handshake")
+            L.append(
+                f"   {s.get('label', '?'):<32} "
+                f"{hps:>7.1f} hs/s  "
+                f"ttfb={ttfb:>6.2f} ms  "
+                f"wire={bw if bw is not None else '?'} B"
+            )
+    L.append("")
+    return L
+
+
 def render_text(r: Report) -> str:
     L: list[str] = []
     sub = "-" * 76
@@ -5744,38 +5782,7 @@ def render_text(r: Report) -> str:
     L.extend(_render_text_openssl(r))
     L.extend(_render_text_pqc_sizes(r))
     L.extend(_render_text_benchmark(r))
-
-    if r.benchmark_tls_handshake:
-        L.append(C.wrap(C.BOLD, "6b. TLS handshake benchmark (loopback)"))
-        b = r.benchmark_tls_handshake
-        if not b.get("available"):
-            L.append(f"   unavailable: {b.get('reason', 'unknown')}")
-        else:
-            L.append(
-                f"   engine: {b.get('engine')}, transport: {b.get('transport')}, "
-                f"{b.get('iterations_per_suite')} handshakes/suite"
-            )
-            for s in b.get("suites") or []:
-                if "error" in s:
-                    L.append(
-                        f"   {s.get('label', s.get('role', '?')):<32} error: {s['error']}"
-                    )
-                    continue
-                if s.get("skipped"):
-                    L.append(
-                        f"   {s.get('label', '?'):<32} skipped: {s.get('reason', '')}"
-                    )
-                    continue
-                hps = s.get("handshakes_per_sec")
-                ttfb = s.get("ttfb_ms_median")
-                bw = s.get("bytes_on_wire_per_handshake")
-                L.append(
-                    f"   {s.get('label', '?'):<32} "
-                    f"{hps:>7.1f} hs/s  "
-                    f"ttfb={ttfb:>6.2f} ms  "
-                    f"wire={bw if bw is not None else '?'} B"
-                )
-        L.append("")
+    L.extend(_render_text_tls_handshake(r))
 
     if r.per_algo:
         L.append(C.wrap(C.BOLD, "7. Per-algorithm production verdict"))

--- a/pqc_readiness.py
+++ b/pqc_readiness.py
@@ -5825,6 +5825,39 @@ def _render_text_production_estimate(r: Report) -> list[str]:
     return L
 
 
+def _render_text_cnsa_2_0(r: Report) -> list[str]:
+    """Section 10: CNSA 2.0 compliance, conditional on r.cnsa_2_0 being set."""
+    if not r.cnsa_2_0:
+        return []
+    L: list[str] = [
+        C.wrap(C.BOLD, "10. CNSA 2.0 compliance (NSA national security suite)")
+    ]
+    status = r.cnsa_2_0.get("status", "unknown")
+    status_color = {
+        "compliant": C.GREEN,
+        "partial": C.YELLOW,
+        "non_compliant": C.RED,
+        "unknown": C.DIM,
+    }.get(status, C.DIM)
+    L.append(f"   Status:                 {C.wrap(status_color, status.upper())}")
+    L.append(
+        f"   ML-KEM-1024 (KEM):      {'yes' if r.cnsa_2_0.get('kem_compliant') else 'no'}"
+    )
+    L.append(
+        f"   ML-DSA-87  (signature): {'yes' if r.cnsa_2_0.get('signature_compliant') else 'no'}"
+    )
+    L.append(
+        f"   AES-256    (symmetric): {'yes' if r.cnsa_2_0.get('symmetric_compliant') else 'no'}"
+    )
+    L.append(
+        f"   SHA-384/512 (hash, hw): {'yes' if r.cnsa_2_0.get('hash_compliant') else 'no'}"
+    )
+    for note in r.cnsa_2_0.get("notes") or []:
+        L.append(C.wrap(C.YELLOW, f"   note: {note}"))
+    L.append("")
+    return L
+
+
 def _render_text_trust_store(r: Report) -> list[str]:
     """Section 9: trust store inventory, conditional on the trust-store
     scanner having run successfully (r.trust_store['available'])."""
@@ -5863,34 +5896,7 @@ def render_text(r: Report) -> str:
     L.extend(_render_text_per_algo(r))
     L.extend(_render_text_production_estimate(r))
     L.extend(_render_text_trust_store(r))
-
-    if r.cnsa_2_0:
-        L.append(
-            C.wrap(C.BOLD, "10. CNSA 2.0 compliance (NSA national security suite)")
-        )
-        status = r.cnsa_2_0.get("status", "unknown")
-        status_color = {
-            "compliant": C.GREEN,
-            "partial": C.YELLOW,
-            "non_compliant": C.RED,
-            "unknown": C.DIM,
-        }.get(status, C.DIM)
-        L.append(f"   Status:                 {C.wrap(status_color, status.upper())}")
-        L.append(
-            f"   ML-KEM-1024 (KEM):      {'yes' if r.cnsa_2_0.get('kem_compliant') else 'no'}"
-        )
-        L.append(
-            f"   ML-DSA-87  (signature): {'yes' if r.cnsa_2_0.get('signature_compliant') else 'no'}"
-        )
-        L.append(
-            f"   AES-256    (symmetric): {'yes' if r.cnsa_2_0.get('symmetric_compliant') else 'no'}"
-        )
-        L.append(
-            f"   SHA-384/512 (hash, hw): {'yes' if r.cnsa_2_0.get('hash_compliant') else 'no'}"
-        )
-        for note in r.cnsa_2_0.get("notes") or []:
-            L.append(C.wrap(C.YELLOW, f"   note: {note}"))
-        L.append("")
+    L.extend(_render_text_cnsa_2_0(r))
 
     L.append(sub)
     L.append(f"  VERDICT: {C.wrap(C.BOLD, r.verdict)}")

--- a/pqc_readiness.py
+++ b/pqc_readiness.py
@@ -5702,6 +5702,38 @@ def _render_text_pqc_sizes(r: Report) -> list[str]:
     return L
 
 
+def _render_text_benchmark(r: Report) -> list[str]:
+    """Section 6: PQC microbenchmark — emitted only when r.benchmark is set."""
+    if not r.benchmark:
+        return []
+    L: list[str] = [C.wrap(C.BOLD, "6. Microbenchmark")]
+    if not r.benchmark.get("available"):
+        L.append(f"   unavailable: {r.benchmark.get('reason', 'unknown')}")
+    else:
+        L.append(
+            f"   engine: {r.benchmark['engine']}, {r.benchmark['seconds_per_test']}s per test, "
+            f"{r.benchmark.get('threads', 1)} thread(s)"
+        )
+        for algo, data in (r.benchmark.get("pqc") or {}).items():
+            L.append(f"   {algo}:")
+            for k, v in data.items():
+                if isinstance(v, dict):
+                    agg = ", ".join(f"{kk}={vv:.1f}" for kk, vv in v.items())
+                    L.append(f"     {k}: {agg}")
+                elif isinstance(v, (int, float)):
+                    L.append(f"     {k:<12} {v:>12.1f}")
+                else:
+                    L.append(f"     {k}: {v}")
+        classical = r.benchmark.get("classical") or {}
+        if classical:
+            L.append("   Classical baseline (per-core):")
+            for name, rates in classical.items():
+                s = ", ".join(f"{k}={v:.1f}" for k, v in rates.items())
+                L.append(f"     {name:<10} {s}")
+    L.append("")
+    return L
+
+
 def render_text(r: Report) -> str:
     L: list[str] = []
     sub = "-" * 76
@@ -5711,33 +5743,7 @@ def render_text(r: Report) -> str:
     L.extend(_render_text_os_crypto(r))
     L.extend(_render_text_openssl(r))
     L.extend(_render_text_pqc_sizes(r))
-
-    if r.benchmark:
-        L.append(C.wrap(C.BOLD, "6. Microbenchmark"))
-        if not r.benchmark.get("available"):
-            L.append(f"   unavailable: {r.benchmark.get('reason', 'unknown')}")
-        else:
-            L.append(
-                f"   engine: {r.benchmark['engine']}, {r.benchmark['seconds_per_test']}s per test, "
-                f"{r.benchmark.get('threads', 1)} thread(s)"
-            )
-            for algo, data in (r.benchmark.get("pqc") or {}).items():
-                L.append(f"   {algo}:")
-                for k, v in data.items():
-                    if isinstance(v, dict):
-                        agg = ", ".join(f"{kk}={vv:.1f}" for kk, vv in v.items())
-                        L.append(f"     {k}: {agg}")
-                    elif isinstance(v, (int, float)):
-                        L.append(f"     {k:<12} {v:>12.1f}")
-                    else:
-                        L.append(f"     {k}: {v}")
-            classical = r.benchmark.get("classical") or {}
-            if classical:
-                L.append("   Classical baseline (per-core):")
-                for name, rates in classical.items():
-                    s = ", ".join(f"{k}={v:.1f}" for k, v in rates.items())
-                    L.append(f"     {name:<10} {s}")
-        L.append("")
+    L.extend(_render_text_benchmark(r))
 
     if r.benchmark_tls_handshake:
         L.append(C.wrap(C.BOLD, "6b. TLS handshake benchmark (loopback)"))

--- a/pqc_readiness.py
+++ b/pqc_readiness.py
@@ -5543,13 +5543,9 @@ def _render_text_isa(r: Report) -> list[str]:
     return L
 
 
-def render_text(r: Report) -> str:
-    L: list[str] = []
-    sub = "-" * 76
-    L.extend(_render_text_header(r))
-    L.extend(_render_text_isa(r))
-
-    L.append(C.wrap(C.BOLD, "2. Cryptographic accelerators / HSMs / TPMs"))
+def _render_text_accelerators(r: Report) -> list[str]:
+    """Section 2: Cryptographic accelerators, HSMs, TPMs, PKCS#11 modules."""
+    L: list[str] = [C.wrap(C.BOLD, "2. Cryptographic accelerators / HSMs / TPMs")]
     if r.accelerators:
         for a in r.accelerators:
             pqc_mark = " [PQC-capable]" if a.get("pqc_capable") else ""
@@ -5578,6 +5574,15 @@ def render_text(r: Report) -> str:
         if len(r.pkcs11_modules) > 5:
             L.append(f"       ... and {len(r.pkcs11_modules) - 5} more")
     L.append("")
+    return L
+
+
+def render_text(r: Report) -> str:
+    L: list[str] = []
+    sub = "-" * 76
+    L.extend(_render_text_header(r))
+    L.extend(_render_text_isa(r))
+    L.extend(_render_text_accelerators(r))
 
     L.append(C.wrap(C.BOLD, "3. Operating-system crypto plumbing"))
     if r.kernel_info:

--- a/pqc_readiness.py
+++ b/pqc_readiness.py
@@ -5658,6 +5658,26 @@ def _render_text_os_crypto(r: Report) -> list[str]:
     return L
 
 
+def _render_text_openssl_tls_groups(tls_groups: dict[str, Any]) -> list[str]:
+    """Section 4 sub-block: TLS PQC group lines (hybrid / pure / classical)."""
+    hybrid = tls_groups.get("hybrid") or []
+    pure = tls_groups.get("pure_pqc") or []
+    classical = tls_groups.get("classical") or []
+    L: list[str] = []
+    if not (hybrid or pure):
+        L.append("   TLS PQC groups: not exposed")
+    else:
+        L.append(
+            f"   TLS PQC groups (hybrid): {', '.join(hybrid) if hybrid else 'none'}"
+        )
+        L.append(
+            f"   TLS PQC groups (pure):   {', '.join(pure) if pure else 'none'}"
+        )
+    if classical:
+        L.append(f"   TLS classical groups:    {len(classical)} detected")
+    return L
+
+
 def _render_text_openssl(r: Report) -> list[str]:
     """Section 4: OpenSSL PQC capability (version, KEMs, sigs, TLS groups)."""
     L: list[str] = [C.wrap(C.BOLD, "4. PQC library capability (OpenSSL)")]
@@ -5672,21 +5692,7 @@ def _render_text_openssl(r: Report) -> list[str]:
         sigs = r.openssl.get("sig_algorithms") or []
         L.append(f"   ML-KEM:        {', '.join(kems) if kems else 'not exposed'}")
         L.append(f"   PQC sigs:      {', '.join(sigs) if sigs else 'not exposed'}")
-        tg = r.openssl.get("tls_groups") or {}
-        hybrid = tg.get("hybrid") or []
-        pure = tg.get("pure_pqc") or []
-        classical = tg.get("classical") or []
-        if not (hybrid or pure):
-            L.append("   TLS PQC groups: not exposed")
-        else:
-            L.append(
-                f"   TLS PQC groups (hybrid): {', '.join(hybrid) if hybrid else 'none'}"
-            )
-            L.append(
-                f"   TLS PQC groups (pure):   {', '.join(pure) if pure else 'none'}"
-            )
-        if classical:
-            L.append(f"   TLS classical groups:    {len(classical)} detected")
+        L.extend(_render_text_openssl_tls_groups(r.openssl.get("tls_groups") or {}))
     L.append("")
     return L
 

--- a/tests/test_render_text_sections.py
+++ b/tests/test_render_text_sections.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-section helper tests for `render_text`.
+
+Audit option B1 split `render_text` into a flat top-level driver plus
+one helper per numbered report section. The existing
+`tests/test_render_text.py` covers `render_text` end-to-end (no `None`
+leaks, all section headings present, partial-population tolerance).
+
+This file complements that with one focused test per helper, so a
+regression in (say) `_render_text_fips` surfaces as a tightly-scoped
+failure rather than as a global golden-output diff. Helpers are
+imported by name; the suite never reaches them through `getattr` or
+reflection.
+"""
+from __future__ import annotations
+
+import pqc_readiness as pr
+from pqc_readiness import (
+    _render_text_accelerators,
+    _render_text_benchmark,
+    _render_text_cnsa_2_0,
+    _render_text_fips,
+    _render_text_header,
+    _render_text_isa,
+    _render_text_kernel_crypto,
+    _render_text_openssl,
+    _render_text_openssl_tls_groups,
+    _render_text_os_crypto,
+    _render_text_per_algo,
+    _render_text_pqc_sizes,
+    _render_text_production_estimate,
+    _render_text_ssh_ipsec_nss,
+    _render_text_tls_handshake,
+    _render_text_trust_store,
+    _render_text_verdict,
+)
+from test_render_text import _make_full_coverage_report
+
+# Color is module-level state; pin off so `C.wrap` is identity and the
+# section-text assertions match the source strings verbatim.
+pr.C.configure(False)
+
+
+def test_header_includes_hostname_and_cpu() -> None:
+    r = _make_full_coverage_report()
+    out = "\n".join(_render_text_header(r))
+    assert r.hostname in out
+    assert r.cpu_model in out
+    assert "Post-Quantum Cryptography Readiness Report" in out
+
+
+def test_isa_emits_section_heading_and_features() -> None:
+    r = _make_full_coverage_report()
+    out = "\n".join(_render_text_isa(r))
+    assert "1. CPU instruction-set support for PQC" in out
+    # Features come from _make_report (AVX-512 IFMA / VBMI).
+    assert "AVX-512 IFMA" in out
+
+
+def test_isa_handles_empty_isa_features() -> None:
+    r = pr.Report()
+    out = "\n".join(_render_text_isa(r))
+    assert "(no PQC-relevant ISA features detected)" in out
+
+
+def test_accelerators_emits_heading_and_pkcs11_count() -> None:
+    r = _make_full_coverage_report()
+    out = "\n".join(_render_text_accelerators(r))
+    assert "2. Cryptographic accelerators / HSMs / TPMs" in out
+    assert "PKCS#11 modules installed: 1" in out
+
+
+def test_accelerators_falls_back_when_none_detected() -> None:
+    r = pr.Report()
+    out = "\n".join(_render_text_accelerators(r))
+    assert "none detected - host would do all PQC in CPU/memory" in out
+
+
+def test_kernel_crypto_emits_distribution_and_kernel() -> None:
+    r = _make_full_coverage_report()
+    out = "\n".join(_render_text_kernel_crypto(r))
+    assert "Distribution:" in out
+    assert "Kernel:" in out
+    # The fixture sets a single PQC driver; the joined line must include it.
+    assert "ml-kem-768" in out
+
+
+def test_fips_block_silent_when_fips_dict_empty() -> None:
+    r = pr.Report()
+    out = _render_text_fips(r)
+    assert out == []
+
+
+def test_fips_block_warns_on_conflict() -> None:
+    r = _make_full_coverage_report()
+    r.fips = {"kernel": True, "openssl_provider": True}
+    r.fips_pqc_conflict = {"in_conflict": True, "explanation": "boom"}
+    out = "\n".join(_render_text_fips(r))
+    assert "FIPS mode:" in out
+    assert "FIPS/PQC conflict" in out
+    assert "boom" in out
+
+
+def test_ssh_ipsec_nss_lists_pqc_kex_groups() -> None:
+    r = _make_full_coverage_report()
+    out = "\n".join(_render_text_ssh_ipsec_nss(r))
+    assert "OpenSSH kex:" in out
+    assert "mlkem768x25519-sha256" in out
+    assert "strongSwan:" in out
+    assert "NSS:" in out
+
+
+def test_os_crypto_umbrella_emits_section_3_heading() -> None:
+    r = _make_full_coverage_report()
+    out = "\n".join(_render_text_os_crypto(r))
+    assert "3. Operating-system crypto plumbing" in out
+
+
+def test_openssl_emits_version_and_kem_list() -> None:
+    r = _make_full_coverage_report()
+    out = "\n".join(_render_text_openssl(r))
+    assert "4. PQC library capability (OpenSSL)" in out
+    assert "Version:" in out
+    assert "ML-KEM-768" in out
+
+
+def test_openssl_unavailable_renders_reason() -> None:
+    r = _make_full_coverage_report()
+    r.openssl = {"available": False, "reason": "openssl not installed"}
+    out = "\n".join(_render_text_openssl(r))
+    assert "openssl not installed" in out
+
+
+def test_openssl_tls_groups_unexposed_when_no_pqc() -> None:
+    out = _render_text_openssl_tls_groups({})
+    assert "TLS PQC groups: not exposed" in out[0]
+
+
+def test_openssl_tls_groups_split_hybrid_pure_classical() -> None:
+    out = "\n".join(
+        _render_text_openssl_tls_groups(
+            {"hybrid": ["X25519MLKEM768"], "pure_pqc": ["MLKEM768"], "classical": ["X25519"]}
+        )
+    )
+    assert "TLS PQC groups (hybrid):" in out
+    assert "X25519MLKEM768" in out
+    assert "TLS classical groups:" in out
+
+
+def test_pqc_sizes_emits_each_algorithm_row() -> None:
+    r = pr.Report()
+    r.pqc_sizes = {"ML-KEM-768": {"role": "kem", "public_key": 1184}}
+    out = "\n".join(_render_text_pqc_sizes(r))
+    assert "5. NIST PQC parameter sizes (bytes)" in out
+    assert "ML-KEM-768" in out
+    assert "public_key=1184" in out
+
+
+def test_benchmark_returns_empty_list_without_data() -> None:
+    r = pr.Report()
+    assert _render_text_benchmark(r) == []
+
+
+def test_benchmark_emits_engine_and_pqc_rows() -> None:
+    r = _make_full_coverage_report()
+    out = "\n".join(_render_text_benchmark(r))
+    assert "6. Microbenchmark" in out
+    assert "engine: openssl" in out
+    assert "ML-KEM-768:" in out
+
+
+def test_tls_handshake_returns_empty_without_data() -> None:
+    r = pr.Report()
+    assert _render_text_tls_handshake(r) == []
+
+
+def test_tls_handshake_emits_per_suite_rates() -> None:
+    r = _make_full_coverage_report()
+    out = "\n".join(_render_text_tls_handshake(r))
+    assert "6b. TLS handshake benchmark (loopback)" in out
+    assert "TLS_AES_128_GCM_SHA256" in out
+    assert "hs/s" in out
+
+
+def test_per_algo_returns_empty_without_data() -> None:
+    r = pr.Report()
+    assert _render_text_per_algo(r) == []
+
+
+def test_per_algo_emits_tier_label_and_notes() -> None:
+    r = _make_full_coverage_report()
+    out = "\n".join(_render_text_per_algo(r))
+    assert "7. Per-algorithm production verdict" in out
+    assert "ml-kem-768" in out
+    assert "informational note" in out
+
+
+def test_production_estimate_returns_empty_without_data() -> None:
+    r = pr.Report()
+    assert _render_text_production_estimate(r) == []
+
+
+def test_production_estimate_emits_thousands_separated() -> None:
+    r = _make_full_coverage_report()
+    out = "\n".join(_render_text_production_estimate(r))
+    assert "8. Production capacity estimate (60% CPU headroom)" in out
+    # Locale-independent comma grouping is enforced by the f-string.
+    assert "~5,000" in out
+    assert "60% CPU headroom" in out
+
+
+def test_trust_store_returns_empty_when_unavailable() -> None:
+    r = pr.Report()
+    assert _render_text_trust_store(r) == []
+
+
+def test_trust_store_emits_categories_when_present() -> None:
+    r = _make_full_coverage_report()
+    out = "\n".join(_render_text_trust_store(r))
+    assert "9. Trust store inventory" in out
+    assert "Categories:" in out
+    assert "classical=142" in out
+
+
+def test_cnsa_2_0_returns_empty_without_data() -> None:
+    r = pr.Report()
+    assert _render_text_cnsa_2_0(r) == []
+
+
+def test_cnsa_2_0_emits_status_and_each_compliance_field() -> None:
+    r = _make_full_coverage_report()
+    out = "\n".join(_render_text_cnsa_2_0(r))
+    assert "10. CNSA 2.0 compliance (NSA national security suite)" in out
+    assert "ML-KEM-1024 (KEM):" in out
+    assert "ML-DSA-87" in out
+    assert "AES-256" in out
+    assert "SHA-384/512" in out
+
+
+def test_verdict_emits_two_horizontal_rules_and_caveat() -> None:
+    r = _make_full_coverage_report()
+    lines = _render_text_verdict(r)
+    rule = "-" * 76
+    assert lines[0] == rule
+    assert lines[-1] == rule
+    body = "\n".join(lines)
+    assert "VERDICT:" in body
+    assert r.verdict_reason in body
+    assert "CAVEAT:" in body  # full-coverage fixture sets one
+
+
+def test_verdict_skips_caveat_when_absent() -> None:
+    r = pr.Report()
+    out = "\n".join(_render_text_verdict(r))
+    assert "CAVEAT" not in out


### PR DESCRIPTION
This PR implements audit option B1 and only that option. No behavior change. Output schemas unchanged.

## Summary

Decompose `render_text` (309 lines, cyclomatic complexity 97 / F-rank) into a flat 17-line driver that calls one helper per numbered report section. Output bytes are unchanged across an 8-fixture golden-output regression set captured before the first edit.

## Cyclomatic complexity (radon cc -s)

**Before:**
```
F 5501:0 render_text - F (97)
```

**After:**
```
F 5906:0 render_text - A (1)
F 5711:0 _render_text_benchmark - C (13)
F 5623:0 _render_text_ssh_ipsec_nss - C (12)
F 5580:0 _render_text_kernel_crypto - C (11)
F 5546:0 _render_text_accelerators - B (10)
F 5661:0 _render_text_openssl_tls_groups - B (9)
F 5681:0 _render_text_openssl - B (8)
F 5743:0 _render_text_tls_handshake - B (8)
F 5799:0 _render_text_production_estimate - B (8)
F 5834:0 _render_text_cnsa_2_0 - B (8)
F 5781:0 _render_text_per_algo - A (5)
F 5501:0 _render_text_header - A (4)
F 5700:0 _render_text_pqc_sizes - A (4)
F 5867:0 _render_text_trust_store - A (4)
F 5530:0 _render_text_isa - A (3)
F 5606:0 _render_text_fips - A (3)
F 5891:0 _render_text_verdict - A (2)
F 5650:0 _render_text_os_crypto - A (1)
```

Every helper is well under the audit's ≤15-cap and the 60-line cap.

## New helpers (in driver order)

1. `_render_text_header` — banner + host identity preamble
2. `_render_text_isa` — section 1 (CPU instruction-set support)
3. `_render_text_accelerators` — section 2 (HSMs, TPMs, PKCS#11)
4. `_render_text_os_crypto` — section 3 umbrella (heading + composes the next three)
   - `_render_text_kernel_crypto` — kernel/proc-crypto/kTLS sub-block
   - `_render_text_fips` — FIPS mode + FIPS/PQC conflict warning
   - `_render_text_ssh_ipsec_nss` — OpenSSH PQC kex / strongSwan / NSS
5. `_render_text_openssl` — section 4 (OpenSSL PQC capability)
   - `_render_text_openssl_tls_groups` — TLS groups sub-block
6. `_render_text_pqc_sizes` — section 5 (NIST parameter sizes)
7. `_render_text_benchmark` — section 6 (microbenchmark, conditional)
8. `_render_text_tls_handshake` — section 6b (TLS handshake bench, conditional)
9. `_render_text_per_algo` — section 7 (per-algorithm verdict, conditional)
10. `_render_text_production_estimate` — section 8 (capacity estimate, conditional)
11. `_render_text_trust_store` — section 9 (trust store, conditional)
12. `_render_text_cnsa_2_0` — section 10 (CNSA 2.0, conditional)
13. `_render_text_verdict` — trailing verdict block

The audit guideline of "roughly 12 small section renderers" is honoured at the section level (12 numbered sections plus a header and verdict). Two sections (3 and 4) needed sub-helpers to land below the cc=15 cap; both retain a single bold-heading entry point so the report's section structure is unchanged.

## Verification

- **Golden-output comparison passed**: 8 fixtures (empty, minimal-cbom, full-coverage, container-mode, fips-active, fips-strict-fence, poor-tier, excellent-tier) captured before the first edit, byte-for-byte identical after every commit.
- **Tests**: 349 pass (320 original + 29 new per-helper tests in `tests/test_render_text_sections.py`).
- **ruff** + **mypy --strict**: clean.
- **scripts/check-no-third-party-refs.sh** + **scripts/check-readme-flags.sh**: pass.

## What this PR is not

- Not the markdown renderer split (cc=25). Out of scope.
- Not the SPDX or SARIF emitter restructuring. Out of scope.
- Not adding new sections to the report output. Out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)