### PR TITLE
refactor: collapse rpm/dpkg/pacman parsers into single whitespace parser (audit A1)

### DIFF
--- a/pqc_readiness.py
+++ b/pqc_readiness.py
@@ -2362,29 +2362,13 @@ BUNDLED_CRYPTO_BY_FAMILY: dict[str, list[tuple[str, str]]] = {
 }
 
 
-def parse_rpm_packages(text: str) -> list[dict[str, str]]:
-    """Parse `rpm -qa --queryformat '%{NAME} %{VERSION}\\n'` output into
-    [{"name", "version"}, ...]."""
-    out: list[dict[str, str]] = []
-    for line in text.splitlines():
-        parts = line.strip().split(None, 1)
-        if len(parts) == 2:
-            out.append({"name": parts[0], "version": parts[1]})
-    return out
+def parse_whitespace_pkg_lines(text: str) -> list[dict[str, str]]:
+    """Parse `name version` per line into [{"name", "version"}, ...].
 
-
-def parse_dpkg_packages(text: str) -> list[dict[str, str]]:
-    """Parse `dpkg-query -W -f='${Package} ${Version}\\n'` output."""
-    out: list[dict[str, str]] = []
-    for line in text.splitlines():
-        parts = line.strip().split(None, 1)
-        if len(parts) == 2:
-            out.append({"name": parts[0], "version": parts[1]})
-    return out
-
-
-def parse_pacman_packages(text: str) -> list[dict[str, str]]:
-    """Parse `pacman -Q` output (`name version` per line)."""
+    Used for rpm (`rpm -qa --queryformat '%{NAME} %{VERSION}\\n'`),
+    dpkg (`dpkg-query -W -f='${Package} ${Version}\\n'`), and pacman
+    (`pacman -Q`) — all three emit the same two-token-per-line format.
+    Apk does not (see `parse_apk_packages` below)."""
     out: list[dict[str, str]] = []
     for line in text.splitlines():
         parts = line.strip().split(None, 1)
@@ -2447,17 +2431,17 @@ PACKAGE_QUERY_BY_FAMILY: dict[
 ] = {
     "rhel": (
         ["rpm", "-qa", "--queryformat", "%{NAME} %{VERSION}\\n"],
-        parse_rpm_packages,
+        parse_whitespace_pkg_lines,
     ),
     "suse": (
         ["rpm", "-qa", "--queryformat", "%{NAME} %{VERSION}\\n"],
-        parse_rpm_packages,
+        parse_whitespace_pkg_lines,
     ),
     "debian": (
         ["dpkg-query", "-W", "-f=${Package} ${Version}\\n"],
-        parse_dpkg_packages,
+        parse_whitespace_pkg_lines,
     ),
-    "arch": (["pacman", "-Q"], parse_pacman_packages),
+    "arch": (["pacman", "-Q"], parse_whitespace_pkg_lines),
     "alpine": (["apk", "info", "-v"], parse_apk_packages),
 }
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -517,7 +517,7 @@ def test_parse_cgroup_for_container_bare_metal() -> None:
 
 def test_parse_rpm_packages() -> None:
     text = "openssl 3.5.5\nnss 3.122.1\nnss 3.122.1\njava-21-openjdk 21.0.5\n"
-    out = pr.parse_rpm_packages(text)
+    out = pr.parse_whitespace_pkg_lines(text)
     assert {"name": "openssl", "version": "3.5.5"} in out
     assert {"name": "java-21-openjdk", "version": "21.0.5"} in out
     assert len(out) == 4
@@ -876,7 +876,7 @@ def test_parse_os_release_strips_quotes_and_comments() -> None:
 
 def test_parse_dpkg_packages_normalises_to_dicts() -> None:
     text = (FIXTURES / "packages" / "dpkg-query-sample.txt").read_text()
-    out = pr.parse_dpkg_packages(text)
+    out = pr.parse_whitespace_pkg_lines(text)
     names = {e["name"] for e in out}
     assert "openjdk-21-jdk" in names
     assert "libbcprov-java" in names
@@ -887,7 +887,7 @@ def test_parse_dpkg_packages_normalises_to_dicts() -> None:
 
 def test_parse_pacman_packages() -> None:
     text = (FIXTURES / "packages" / "pacman-q-sample.txt").read_text()
-    out = pr.parse_pacman_packages(text)
+    out = pr.parse_whitespace_pkg_lines(text)
     by_name = {e["name"]: e["version"] for e in out}
     assert by_name["jdk21-openjdk"] == "21.0.5.u11-1"
     assert by_name["nodejs"] == "22.11.0-1"
@@ -906,7 +906,7 @@ def test_parse_apk_packages_handles_release_suffix() -> None:
 
 def test_classify_bundled_crypto_debian_finds_distinct_names() -> None:
     text = (FIXTURES / "packages" / "dpkg-query-sample.txt").read_text()
-    pkgs = pr.parse_dpkg_packages(text)
+    pkgs = pr.parse_whitespace_pkg_lines(text)
     out = pr.classify_bundled_crypto(pkgs, family="debian")
     names = {p["package"] for p in out}
     # Debian uses openjdk-XX-jdk / openjdk-XX-jre; the regex catches all four.
@@ -925,7 +925,7 @@ def test_classify_bundled_crypto_debian_finds_distinct_names() -> None:
 
 def test_classify_bundled_crypto_arch_uses_arch_naming() -> None:
     text = (FIXTURES / "packages" / "pacman-q-sample.txt").read_text()
-    pkgs = pr.parse_pacman_packages(text)
+    pkgs = pr.parse_whitespace_pkg_lines(text)
     out = pr.classify_bundled_crypto(pkgs, family="arch")
     names = {p["package"] for p in out}
     # Arch ships `jdk21-openjdk` (vs. RHEL `java-21-openjdk`, Debian


### PR DESCRIPTION
This PR implements audit option A1 and only that option. No behavior change. Output schemas unchanged.

## Summary

`parse_rpm_packages`, `parse_dpkg_packages`, and `parse_pacman_packages` had byte-identical bodies — verified:

```
parse_rpm_packages:
    out: list[dict[str, str]] = []
    for line in text.splitlines():
        parts = line.strip().split(None, 1)
        if len(parts) == 2:
            out.append({"name": parts[0], "version": parts[1]})
    return out
---
parse_dpkg_packages:
    <identical>
---
parse_pacman_packages:
    <identical>
```

They differed only by docstring text. Replace with a single `parse_whitespace_pkg_lines` whose docstring enumerates the three commands that share the format. `parse_apk_packages` is **untouched** — apk's `name-VERSION-rRELEASE` format is structurally different and needs its own regex-based parser.

## PACKAGE_QUERY_BY_FAMILY diff

```diff
 PACKAGE_QUERY_BY_FAMILY: dict[
     str, tuple[list[str], Callable[[str], list[dict[str, str]]]]
 ] = {
     "rhel": (
         ["rpm", "-qa", "--queryformat", "%{NAME} %{VERSION}\\n"],
-        parse_rpm_packages,
+        parse_whitespace_pkg_lines,
     ),
     "suse": (
         ["rpm", "-qa", "--queryformat", "%{NAME} %{VERSION}\\n"],
-        parse_rpm_packages,
+        parse_whitespace_pkg_lines,
     ),
     "debian": (
         ["dpkg-query", "-W", "-f=${Package} ${Version}\\n"],
-        parse_dpkg_packages,
+        parse_whitespace_pkg_lines,
     ),
-    "arch": (["pacman", "-Q"], parse_pacman_packages),
+    "arch": (["pacman", "-Q"], parse_whitespace_pkg_lines),
     "alpine": (["apk", "info", "-v"], parse_apk_packages),
 }
```

The two-tuple shape is unchanged; only the parser callable for the four whitespace-format families now resolves to the same target. The apk entry is unchanged.

## Line-count change

- Three 9-line functions removed (27 lines)
- One 11-line function added (slightly larger docstring documenting the three sharers)
- Net: −16 lines from the function bodies, plus mechanical updates in the registry. Audit predicted ~−11; we land at −16 because the consolidated docstring is shorter than the three combined preamble docstrings.

## Verification

- **Tests**: 320 pass — same count as before. Three test bodies updated to call `parse_whitespace_pkg_lines`; test function names retain their package-manager labels because they describe which fixture they exercise.
- **`parse_apk_packages` untouched**: confirmed via `git diff` — only the three rpm/dpkg/pacman parsers and the four registry entries that referenced them changed.
- **ruff** + **mypy --strict**: clean.
- **scripts/check-no-third-party-refs.sh** + **scripts/check-readme-flags.sh**: pass.

## What this PR is not

- Not folding apk parsing in. The format is structurally different.
- Not changing `PACKAGE_QUERY_BY_FAMILY`'s shape. Same two-tuples; three of them now point at the same callable.
- Not adding a fifth package manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)