### PR TITLE
perf: cache openssl version output for process lifetime (audit C1)

### DIFF
--- a/pqc_readiness.py
+++ b/pqc_readiness.py
@@ -42,6 +42,7 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import functools
 import json
 import os
 import platform
@@ -478,6 +479,15 @@ def _run(cmd: list[str], timeout: int = 10) -> tuple[int, str]:
         return p.returncode, (p.stdout or "") + (p.stderr or "")
     except (subprocess.TimeoutExpired, OSError) as e:
         return 127, str(e)
+
+
+# openssl version output is constant for the process lifetime; cache to
+# avoid repeated subprocess calls.
+@functools.lru_cache(maxsize=None)
+def _openssl_version_text() -> tuple[int, str]:
+    """Return cached (rc, text) from `openssl version`. Constant per process.
+    Tests requiring a fresh subprocess call must invoke .cache_clear()."""
+    return _run(["openssl", "version"], timeout=5)
 
 
 def _sysctl(key: str) -> str:
@@ -2806,7 +2816,7 @@ def openssl_capability(os_release: dict[str, Any] | None = None) -> dict[str, An
     if not shutil.which("openssl"):
         return {"available": False, "reason": "openssl not on PATH"}
     out: dict[str, Any] = {"available": True}
-    rc, ver = _run(["openssl", "version"], timeout=5)
+    rc, ver = _openssl_version_text()
     out["version"] = ver.strip() if rc == 0 else "unknown"
     m = re.search(r"OpenSSL\s+(\d+)\.(\d+)\.(\d+)", out["version"])
     out["version_tuple"] = (
@@ -2999,7 +3009,7 @@ def run_classical_baseline(seconds: int) -> dict[str, dict[str, float]]:
 def run_benchmarks(seconds: int = 1, threads: int = 1) -> dict[str, Any]:
     if not shutil.which("openssl"):
         return {"available": False, "reason": "openssl not on PATH"}
-    rc, ver = _run(["openssl", "version"], timeout=5)
+    rc, ver = _openssl_version_text()
     m = re.search(r"OpenSSL\s+(\d+)\.(\d+)", ver)
     if not m or (int(m.group(1)), int(m.group(2))) < (3, 5):
         return {"available": False, "reason": f"OpenSSL pre-3.5 (got {ver.strip()})"}
@@ -3454,7 +3464,7 @@ def run_tls_handshake_bench(
     """
     if not shutil.which("openssl"):
         return {"available": False, "reason": "openssl not on PATH"}
-    rc, ver = _run(["openssl", "version"], timeout=5)
+    rc, ver = _openssl_version_text()
     m = re.search(r"OpenSSL\s+(\d+)\.(\d+)", ver)
     if not m or (int(m.group(1)), int(m.group(2))) < (3, 5):
         return {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,8 +8,20 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 FIXTURES = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture(autouse=True)
+def _clear_openssl_version_cache() -> None:
+    """`_openssl_version_text` is process-cached for runtime efficiency
+    (audit C1). In tests, monkeypatching `_run` is invisible once the
+    cache is hot — clear before every test so each one starts with a
+    fresh subprocess invocation."""
+    import pqc_readiness as pr
+    pr._openssl_version_text.cache_clear()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for module-level helpers in `pqc_readiness`.
+
+Audit option C1 introduced `_openssl_version_text` — a memoized wrapper
+over `_run(['openssl', 'version'])` that avoids three redundant
+subprocess invocations on every default scan. The contract under test
+here is the cache itself, not the underlying binary's output."""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import pqc_readiness as pr
+
+
+def test_openssl_version_text_caches_subprocess_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The helper must invoke `_run` exactly once across multiple calls
+    in the same process, regardless of how many call sites consume it."""
+    calls: list[tuple[Any, ...]] = []
+
+    def counting_run(cmd: list[str], timeout: int = 10) -> tuple[int, str]:
+        calls.append((tuple(cmd), timeout))
+        return 0, "OpenSSL 3.5.5 27 Jan 2026\n"
+
+    # The autouse conftest fixture cleared the cache before this test.
+    monkeypatch.setattr(pr, "_run", counting_run)
+
+    first = pr._openssl_version_text()
+    second = pr._openssl_version_text()
+    third = pr._openssl_version_text()
+
+    assert first == second == third == (0, "OpenSSL 3.5.5 27 Jan 2026\n")
+    assert len(calls) == 1, (
+        f"_openssl_version_text should invoke _run exactly once across "
+        f"three calls, but recorded {len(calls)} invocations: {calls}"
+    )
+    # And the single invocation should preserve the documented argv + timeout.
+    assert calls[0] == (("openssl", "version"), 5)
+
+
+def test_openssl_version_text_cache_clear_resets_subprocess(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`.cache_clear()` is part of the public test contract documented
+    in the helper's docstring — without it, monkeypatched _run would be
+    invisible across tests."""
+    calls: list[int] = []
+
+    def counting_run(cmd: list[str], timeout: int = 10) -> tuple[int, str]:
+        calls.append(1)
+        return 0, "OpenSSL 3.5.5 27 Jan 2026\n"
+
+    monkeypatch.setattr(pr, "_run", counting_run)
+
+    pr._openssl_version_text()
+    assert len(calls) == 1
+    pr._openssl_version_text()
+    assert len(calls) == 1  # cached
+
+    pr._openssl_version_text.cache_clear()
+    pr._openssl_version_text()
+    assert len(calls) == 2  # subprocess re-invoked after cache_clear


### PR DESCRIPTION
This PR implements audit option C1 and only that option. No behavior change. Output schemas unchanged.

## Summary

`openssl version` was invoked at three independent call sites — each forking a subprocess to parse the same constant output. Wrap with a memoized `_openssl_version_text` (functools.lru_cache).

## Helper

```python
# openssl version output is constant for the process lifetime; cache to
# avoid repeated subprocess calls.
@functools.lru_cache(maxsize=None)
def _openssl_version_text() -> tuple[int, str]:
    """Return cached (rc, text) from `openssl version`. Constant per process.
    Tests requiring a fresh subprocess call must invoke .cache_clear()."""
    return _run(["openssl", "version"], timeout=5)
```

## Three call sites updated

| Function | Before | After |
| --- | --- | --- |
| `openssl_capability()` | `rc, ver = _run(["openssl", "version"], timeout=5)` | `rc, ver = _openssl_version_text()` |
| `run_benchmarks()` | `rc, ver = _run(["openssl", "version"], timeout=5)` | `rc, ver = _openssl_version_text()` |
| `run_tls_handshake_bench()` | `rc, ver = _run(["openssl", "version"], timeout=5)` | `rc, ver = _openssl_version_text()` |

The (rc, ver) tuple unpacking is unchanged because `_openssl_version_text` returns the same `tuple[int, str]` shape that `_run` does. No error-handling branches were touched.

## Subprocess call-count change

Measured by wrapping `pr._run` with a counting decorator and exercising the three openssl-version-using paths in sequence:

```
Before:  3 openssl version subprocess calls (11 total subprocess calls)
After:   1 openssl version subprocess call (9 total subprocess calls)
```

Consistent with the audit's prediction: default scan saves 1 invocation (12 → 11), `--bench` path saves 2 (17 → 15) — the difference depends on whether `run_benchmarks` and `run_tls_handshake_bench` both run.

## Tests

- New `tests/test_helpers.py` with two cache-contract assertions:
  - Three calls to `_openssl_version_text()` produce only one `_run` invocation
  - `.cache_clear()` restores fresh-subprocess behavior
- `tests/conftest.py` adds an autouse fixture `_clear_openssl_version_cache` that calls `_openssl_version_text.cache_clear()` before every test so monkeypatched `_run` remains visible (without this, two tests in `test_tls_bench.py` regress because the cache holds the real openssl version even after `_run` is mocked).
- 322 tests pass (320 original + 2 new). ruff + mypy --strict clean.

## What this PR is not

- Not memoizing other subprocess calls. `lspci -nn` is already invoked once. Each `openssl list -*` call returns different output for a different algorithm class.
- Not refactoring `_run` itself.
- Not changing the timeout value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)